### PR TITLE
0.x dev/feature/command

### DIFF
--- a/Command/Runjob.php
+++ b/Command/Runjob.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use EthanYehuda\CronjobManager\Model\Manager;
 use \Magento\Framework\App\State;
 use \Magento\Framework\Console\Cli;
-use \Magento\Framework\Stdlib\DateTime\DateTime;
+use \Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 
 class Runjob extends Command
 {
@@ -25,18 +25,18 @@ class Runjob extends Command
 	private $state;
 	
 	/**
-	 * @var \Magento\Framework\Stdlib\DateTime\DateTime $dateTime
+	 * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface $timezone
 	 */
-	private $dateTime;
+	private $timezone;
 	
 	public function __construct(
 		State $state,
 		Manager $manager,
-		DateTime $dateTime
+		TimezoneInterface $timezone
 	) {
 			$this->manager = $manager;
 			$this->state = $state;
-			$this->dateTime = $dateTime;
+			$this->timezone = $timezone;
 			parent::__construct();
 	}
 	protected function configure()
@@ -62,7 +62,7 @@ class Runjob extends Command
 			
 			// lets create a new cron job and dispatch it
 			$jobCode = $input->getArgument(self::INPUT_KEY_JOB_CODE);
-			$now = strftime('%Y-%m-%dT%H:%M:%S', $this->dateTime->gmtTimestamp());
+			$now = strftime('%Y-%m-%dT%H:%M:%S', $this->timezone->scopeTimeStamp());
 			
 			$schedule = $this->manager->createCronJob($jobCode, $now);
 			$this->manager->dispatchCron(null, $jobCode, $schedule);

--- a/Command/Runjob.php
+++ b/Command/Runjob.php
@@ -4,12 +4,16 @@ namespace EthanYehuda\CronjobManager\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
 use EthanYehuda\CronjobManager\Model\Manager;
 use \Magento\Framework\App\State;
 use \Magento\Framework\Console\Cli;
+use \Magento\Framework\Stdlib\DateTime\DateTime;
 
 class Runjob extends Command
 {
+	const INPUT_KEY_JOB_CODE = 'job_code';
+	
 	/**
 	 * @var EthanYehuda\CronjobManager\Model\Manager $manager
 	 */
@@ -20,18 +24,34 @@ class Runjob extends Command
 	 */
 	private $state;
 	
+	/**
+	 * @var \Magento\Framework\Stdlib\DateTime\DateTime $dateTime
+	 */
+	private $dateTime;
+	
 	public function __construct(
 		State $state,
-		Manager $manager
+		Manager $manager,
+		DateTime $dateTime
 	) {
 			$this->manager = $manager;
 			$this->state = $state;
+			$this->dateTime = $dateTime;
 			parent::__construct();
 	}
 	protected function configure()
 	{
+		$arguments = [
+			new InputArgument(
+				self::INPUT_KEY_JOB_CODE,
+				InputArgument::REQUIRED,
+				'Job code input (ex. \'sitemap_generate\')'
+			)
+		];
+		
 		$this->setName("cronmanager:runjob");
-		$this->setDescription("Run a specific cron job code ");
+		$this->setDescription("Run a specific cron job by its job_code ");
+		$this->setDefinition($arguments);
 		parent::configure();
 	}
 	
@@ -39,6 +59,13 @@ class Runjob extends Command
 	{
 		try {
 			$this->state->setAreaCode('adminhtml');
+			
+			// lets create a new cron job and dispatch it
+			$jobCode = $input->getArgument(self::INPUT_KEY_JOB_CODE);
+			$now = strftime('%Y-%m-%dT%H:%M:%S', $this->dateTime->gmtTimestamp());
+			
+			$schedule = $this->manager->createCronJob($jobCode, $now);
+			$this->manager->dispatchCron(null, $jobCode, $schedule);
 			
 			return Cli::RETURN_SUCCESS;
 		} catch (\Magento\Framework\Exception\LocalizedException $e) {

--- a/Command/Runjob.php
+++ b/Command/Runjob.php
@@ -66,7 +66,7 @@ class Runjob extends Command
 			
 			$schedule = $this->manager->createCronJob($jobCode, $now);
 			$this->manager->dispatchCron(null, $jobCode, $schedule);
-			
+			$output->writeln("$jobCode successfully ran");
 			return Cli::RETURN_SUCCESS;
 		} catch (\Magento\Framework\Exception\LocalizedException $e) {
 			$output->writeln($e->getMessage());

--- a/Command/Runjob.php
+++ b/Command/Runjob.php
@@ -1,0 +1,49 @@
+<?php
+namespace EthanYehuda\CronjobManager\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use EthanYehuda\CronjobManager\Model\Manager;
+use \Magento\Framework\App\State;
+use \Magento\Framework\Console\Cli;
+
+class Runjob extends Command
+{
+	/**
+	 * @var EthanYehuda\CronjobManager\Model\Manager $manager
+	 */
+	private $manager;
+	
+	/**
+	 * @var \Magento\Framework\App\State $state
+	 */
+	private $state;
+	
+	public function __construct(
+		State $state,
+		Manager $manager
+	) {
+			$this->manager = $manager;
+			$this->state = $state;
+			parent::__construct();
+	}
+	protected function configure()
+	{
+		$this->setName("cronmanager:runjob");
+		$this->setDescription("Run a specific cron job code ");
+		parent::configure();
+	}
+	
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		try {
+			$this->state->setAreaCode('adminhtml');
+			
+			return Cli::RETURN_SUCCESS;
+		} catch (\Magento\Framework\Exception\LocalizedException $e) {
+			$output->writeln($e->getMessage());
+			return Cli::RETURN_FAILURE;
+		}
+	}
+}

--- a/Command/Showjobs.php
+++ b/Command/Showjobs.php
@@ -1,0 +1,73 @@
+<?php
+namespace EthanYehuda\CronjobManager\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use EthanYehuda\CronjobManager\Model\Manager;
+use \Magento\Framework\App\State;
+use \Magento\Framework\Console\Cli;
+
+class Showjobs extends Command
+{
+	/**
+	 * @var EthanYehuda\CronjobManager\Model\Manager $manager
+	 */
+	private $manager;
+	
+	/**
+	 * @var \Magento\Framework\App\State $state
+	 */
+	private $state;
+	
+	/**
+	 * @var Array $headers
+	 */
+	private $headers = ['Code', 'Group', 'Frequency', 'Class'];
+	
+	public function __construct(
+		State $state,
+		Manager $manager
+	) {
+		$this->manager = $manager;
+		$this->state = $state;
+		parent::__construct();
+	}
+    protected function configure()
+    {
+        $this->setName("cronmanager:showjobs");
+        $this->setDescription("Show all cron jobs in Magento");
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+        	$this->state->setAreaCode('adminhtml');
+        	
+        	$jobs = $this->manager->getCronJobs();
+        	$table = $this->getHelperSet()->get('table')->setHeaders($this->headers);
+        	
+        	foreach ($jobs as $group => $crons) {
+        		foreach ($crons as $code => $job) {
+        			$instance = $job['instance'];
+        			$method = $job['method'];
+        			$schedule = (isset($job['schedule']) ? $job['schedule'] : "");
+        			$jobData = [
+        				$code,
+        				$group,
+        				$schedule,
+        				"$instance::$method"
+        			];
+        			$table->addRow($jobData);
+        		}
+        	}
+        	
+        	$table->render($output);
+        	return Cli::RETURN_SUCCESS;
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+        	$output->writeln($e->getMessage());
+        	return Cli::RETURN_FAILURE;
+        }
+    }
+} 

--- a/Model/Manager.php
+++ b/Model/Manager.php
@@ -58,13 +58,15 @@ class Manager extends ProcessCronQueueObserver
 		}
 	}
 	
-	public function dispatchCron($jobId, $jobCode)
+	public function dispatchCron($jobId = null, $jobCode, $schedule = null)
 	{
 		$groups = $this->_config->getJobs();
 		$groupId = $this->getGroupId($jobCode, $groups);
 		$jobConfig = $groups[$groupId][$jobCode];
-		$schedule = $this->loadSchedule($jobId);
 		$scheduledTime = $this->timezone->scopeTimeStamp();
+		if(is_null($schedule)) {
+			$schedule = $this->loadSchedule($jobId);
+		}
 		
 		/* We need to trick the method into thinking it should run now so we
 		 * set the scheduled and current time to be equal to one another 

--- a/Model/Manager.php
+++ b/Model/Manager.php
@@ -22,6 +22,7 @@ class Manager extends ProcessCronQueueObserver
 			->setScheduledAt($filteredTime);
 
 		$schedule->getResource()->save($schedule);
+		return $schedule;
 	}
 	
 	public function saveCronJob($jobId, $jobCode = null, $status = null, $time = null)

--- a/Model/Manager.php
+++ b/Model/Manager.php
@@ -71,6 +71,11 @@ class Manager extends ProcessCronQueueObserver
 		$this->_runJob($scheduledTime, $scheduledTime, $jobConfig, $schedule, $groupId);
 		$schedule->getResource()->save($schedule);
 	}
+
+    public function getCronJobs()
+    {
+        return $this->_config->getJobs();
+    }
 	
 	// ========================= UTILITIES ========================= //
 	

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -20,4 +20,11 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="ethanyehuda_cronjobmanager_command_runjob" xsi:type="object">EthanYehuda\CronjobManager\Command\Runjob</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,4 +13,11 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="ethanyehuda_cronjobmanager_command_showjobs" xsi:type="object">EthanYehuda\CronjobManager\Command\Showjobs</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
## Command Line Interface: Cronmanager [_0.x BACKPORT_]

* Back port from PR #14 

    * Needed to ensure that we're saving times **NOT** in UTC 

### Allows user to view all registered job_codes in the system

`php bin/magento cronmanager:showjobs`

![image](https://user-images.githubusercontent.com/6549623/33865393-8e215852-debf-11e7-8a86-4adfd3507bad.png)

### Adds the ability to run a specific cron job from the command line

`php bin/magento cronmanager:runjob indexer_update_all_views`

![image](https://user-images.githubusercontent.com/6549623/33865486-f101e928-debf-11e7-9572-e1e6686bcbcf.png)

  
  