### PR TITLE
Travis Config / Basic Integration Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,49 @@
+sudo: required
+dist: trusty
+group: edge
+addons:
+  apt:
+    packages:
+    - mysql-server-5.6
+    - mysql-client-core-5.6
+    - mysql-client-5.6
+    - postfix
+  hosts:
+      - magento2.travis
+language: php
+matrix:
+  include:
+    - php: 7.1
+      env:
+       - MAGENTO_VERSION=2.3-develop
+       - TEST_SUITE=integration
+    - php: 7.1
+      env:
+        - MAGENTO_VERSION=2.2-develop
+        - TEST_SUITE=integration
+    - php: 7.1
+      env:
+        - MAGENTO_VERSION=2.2.2
+        - TEST_SUITE=integration
+    - php: 7.0
+      env:
+       - MAGENTO_VERSION=2.3-develop
+       - TEST_SUITE=integration
+    - php: 7.0
+      env:
+        - MAGENTO_VERSION=2.2-develop
+        - TEST_SUITE=integration
+    - php: 7.0
+      env:
+        - MAGENTO_VERSION=2.2.2
+        - TEST_SUITE=integration
+env:
+  global:
+    - COMPOSER_BIN_DIR=~/bin
+    - COMPOSER_PACKAGE_NAME=ethanyehuda/magento2-cronjobmanager
+cache:
+  apt: true
+  directories:
+    - $HOME/.composer/cache
+before_script: ./.travis/before_script.sh
+script: phpunit -c magento2/dev/tests/$TEST_SUITE

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -e
+trap '>&2 echo Error: Command \`$BASH_COMMAND\` on line $LINENO failed with exit code $?' ERR
+
+# mock mail
+sudo service postfix stop
+echo # print a newline
+smtp-sink -d "%d.%H.%M.%S" localhost:2500 1000 &
+echo 'sendmail_path = "/usr/sbin/sendmail -t -i "' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/sendmail.ini
+
+# disable xdebug and adjust memory limit
+echo > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+phpenv rehash;
+
+composer selfupdate
+
+# clone main magento github repository
+git clone --branch $MAGENTO_VERSION --depth=1 https://github.com/magento/magento2
+
+# install Magento
+cd magento2
+
+# add composer package under test, composer require will trigger update/install
+composer config minimum-stability dev
+composer config repositories.travis_to_test git https://github.com/$TRAVIS_REPO_SLUG.git
+composer require $COMPOSER_PACKAGE_NAME:dev-$TRAVIS_BRANCH#$TRAVIS_COMMIT
+
+# prepare for test suite
+case $TEST_SUITE in
+    integration)
+        cp vendor/$COMPOSER_PACKAGE_NAME/Test/Integration/phpunit.xml.dist dev/tests/integration/phpunit.xml
+
+        cd dev/tests/integration
+
+        # create database and move db config into place
+        mysql -uroot -e '
+            SET @@global.sql_mode = NO_ENGINE_SUBSTITUTION;
+            CREATE DATABASE magento_integration_tests;
+        '
+        mv etc/install-config-mysql.travis.php.dist etc/install-config-mysql.php
+
+        cd ../../..
+        ;;
+    unit)
+        cp vendor/$COMPOSER_PACKAGE_NAME/Test/Unit/phpunit.xml.dist dev/tests/unit/phpunit.xml
+    ;;
+esac

--- a/Test/Integration/Controller/Adminhtml/Manage/CreateTest.php
+++ b/Test/Integration/Controller/Adminhtml/Manage/CreateTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Test\Integration\Controller\Adminhtml\Manage;
+
+use Magento\TestFramework\TestCase\AbstractBackendController;
+
+class CreateTest extends AbstractBackendController
+{
+    protected $uri = 'backend/cronjobmanager/manage/create';
+
+    protected $resource = 'EthanYehuda_CronjobManager::cronjobmanager';
+
+    public function testEditAction()
+    {
+        $this->dispatch($this->uri);
+        $result = $this->getResponse()->getBody();
+
+        $this->assertContains('<title>Create Cron Job / Tools / System / Magento Admin</title>', $result);
+    }
+}

--- a/Test/Integration/Controller/Adminhtml/Manage/EditTest.php
+++ b/Test/Integration/Controller/Adminhtml/Manage/EditTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Test\Integration\Controller\Adminhtml\Manage;
+
+use Magento\TestFramework\TestCase\AbstractBackendController;
+
+class EditTest extends AbstractBackendController
+{
+    protected $uri = 'backend/cronjobmanager/manage/edit/id/1';
+
+    protected $resource = 'EthanYehuda_CronjobManager::cronjobmanager';
+
+    public function testEditAction()
+    {
+        $this->dispatch($this->uri);
+        $result = $this->getResponse()->getBody();
+
+        $this->assertContains('<title>Edit Cron Job / Tools / System / Magento Admin</title>', $result);
+    }
+}

--- a/Test/Integration/Controller/Adminhtml/Manage/IndexTest.php
+++ b/Test/Integration/Controller/Adminhtml/Manage/IndexTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Test\Integration\Controller\Adminhtml\Manage;
+
+use Magento\TestFramework\TestCase\AbstractBackendController;
+
+class IndexTest extends AbstractBackendController
+{
+    protected $uri = 'backend/cronjobmanager/manage';
+
+    protected $resource = 'EthanYehuda_CronjobManager::cronjobmanager';
+
+    /**
+     * @magentoDataFixture loadDataFixtureCron
+     */
+    public function testIndexAction()
+    {
+        $this->dispatch($this->uri);
+        $result = $this->getResponse()->getBody();
+
+        $this->assertContains('<title>Cron Job Dashboard / Tools / System / Magento Admin</title>', $result);
+    }
+
+    public static function loadDataFixtureCron()
+    {
+        include __DIR__ . '/../../../_files/cron.php';
+    }
+}

--- a/Test/Integration/Model/ManagerTest.php
+++ b/Test/Integration/Model/ManagerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Test\Integration\Model;
+
+use Magento\Cron\Model\Schedule;
+use PHPUnit\Framework\TestCase;
+use Magento\TestFramework\Helper\Bootstrap;
+use EthanYehuda\CronjobManager\Model\Manager;
+use Magento\Cron\Model\ScheduleFactory;
+
+class ManagerTest extends TestCase
+{
+    const FIXTURE_CRON_ID = 1;
+    /**
+     * @var Manager
+     */
+    private $manager;
+
+    /**
+     * @var ScheduleFactory
+     */
+    private $scheduleFactory;
+
+    protected function setUp()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        
+        $this->manager = $objectManager->create(Manager::class);
+        $this->scheduleFactory = $objectManager->create(ScheduleFactory::class);
+    }
+
+    public function testCreateCronJob()
+    {
+        $cronJob = $this->manager->createCronJob(
+            'expired_tokens_cleanup',
+            strftime('%Y-%m-%dT%H:%M', strtotime('+5 minutes'))
+        );
+
+        $this->assertInstanceOf(Schedule::class, $cronJob);
+    }
+
+    /**
+     * @magentoDataFixture loadDataFixtureCron
+     */
+    public function testSaveCronJob()
+    {
+        $this->manager->saveCronJob(self::FIXTURE_CRON_ID, null, Schedule::STATUS_SUCCESS);
+        $cron = $this->loadCron(self::FIXTURE_CRON_ID);
+
+        $this->assertEquals(Schedule::STATUS_SUCCESS, $cron->getStatus());
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function testSaveCronInvalidId()
+    {
+        $this->manager->saveCronJob(99999);
+    }
+
+    /**
+     * @magentoDataFixture loadDataFixtureCron
+     */
+    public function testDeleteCronJob()
+    {
+        $this->manager->deleteCronJob(self::FIXTURE_CRON_ID);
+        $cron = $this->loadCron(self::FIXTURE_CRON_ID);
+
+        $this->assertNull($cron->getScheduleId());
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function testDeleteInvalidId()
+    {
+        $this->manager->deleteCronJob(99999);
+    }
+
+    public function testGetCronJobs()
+    {
+        $jobs = $this->manager->getCronJobs();
+
+        $this->assertArrayHasKey('default', $jobs);
+    }
+
+    public static function loadDataFixtureCron()
+    {
+        include __DIR__ . '/../_files/cron.php';
+    }
+
+    /**
+     * @param int $id
+     * @return \Magento\Cron\Model\Schedule
+     */
+    private function loadCron($id)
+    {
+        $cron = $this->scheduleFactory->create();
+        $cron->getResource()->load($cron, $id);
+
+        return $cron;
+    }
+}

--- a/Test/Integration/_files/cron.php
+++ b/Test/Integration/_files/cron.php
@@ -1,0 +1,18 @@
+<?php
+
+use Magento\Cron\Model\Schedule;
+use Magento\TestFramework\Helper\Bootstrap;
+use EthanYehuda\CronjobManager\Test\Integration\Model\ManagerTest;
+
+$objectManager = Bootstrap::getObjectManager();
+
+/** @var Schedule $cron */
+$cron = $objectManager->create(Schedule::class);
+
+$cron->setId(ManagerTest::FIXTURE_CRON_ID)
+    ->setJobCode('fake_job')
+    ->setStatus(Schedule::STATUS_PENDING)
+    ->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
+    ->setScheduledAt(strftime('%Y-%m-%d %H:%M:%S', strtotime('+5 minutes')));
+
+$cron->save();

--- a/Test/Integration/phpunit.xml.dist
+++ b/Test/Integration/phpunit.xml.dist
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.2/phpunit.xsd"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="./framework/bootstrap.php"
+         stderr="true"
+>
+    <!-- Test suites definition -->
+    <testsuites>
+        <testsuite name="CronjobManager Integration Tests">
+            <directory suffix="Test.php">../../../vendor/ethanyehuda/magento2-cronjobmanager/Test/Integration</directory>
+        </testsuite>
+    </testsuites>
+    <!-- Code coverage filters -->
+    <filter>
+        <whitelist addUncoveredFilesFromWhiteList="true">
+            <directory suffix=".php">../../../vendor/ethanyehuda/magento2-cronjobmanager</directory>
+            <exclude>
+                <directory>../../../vendor/ethanyehuda/magento2-cronjobmanager/Test</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <!-- PHP INI settings and constants definition -->
+    <php>
+        <includePath>.</includePath>
+        <includePath>testsuite</includePath>
+        <ini name="date.timezone" value="America/Los_Angeles"/>
+        <ini name="xdebug.max_nesting_level" value="200"/>
+        <!-- Local XML configuration file ('.dist' extension will be added, if the specified file doesn't exist) -->
+        <const name="TESTS_INSTALL_CONFIG_FILE" value="etc/install-config-mysql.php"/>
+        <!-- Local XML configuration file ('.dist' extension will be added, if the specified file doesn't exist) -->
+        <const name="TESTS_GLOBAL_CONFIG_FILE" value="etc/config-global.php"/>
+        <!-- Semicolon-separated 'glob' patterns, that match global XML configuration files -->
+        <const name="TESTS_GLOBAL_CONFIG_DIR" value="../../../app/etc"/>
+        <!-- Whether to cleanup the application before running tests or not -->
+        <!--<const name="TESTS_CLEANUP" value="enabled"/>-->
+        <const name="TESTS_CLEANUP" value="enabled" />
+        <!-- Memory usage and estimated leaks thresholds -->
+        <!--<const name="TESTS_MEM_USAGE_LIMIT" value="1024M"/>-->
+        <const name="TESTS_MEM_LEAK_LIMIT" value=""/>
+        <!-- Whether to output all CLI commands executed by the bootstrap and tests -->
+        <!--<const name="TESTS_EXTRA_VERBOSE_LOG" value="1"/>-->
+        <!-- Path to Percona Toolkit bin directory -->
+        <!--<const name="PERCONA_TOOLKIT_BIN_DIR" value=""/>-->
+        <!-- CSV Profiler Output file -->
+        <!--<const name="TESTS_PROFILER_FILE" value="profiler.csv"/>-->
+        <!-- Bamboo compatible CSV Profiler Output file name -->
+        <!--<const name="TESTS_BAMBOO_PROFILER_FILE" value="profiler.csv"/>-->
+        <!-- Metrics for Bamboo Profiler Output in PHP file that returns array -->
+        <!--<const name="TESTS_BAMBOO_PROFILER_METRICS_FILE" value="../../build/profiler_metrics.php"/>-->
+        <!-- Whether to output all CLI commands executed by the bootstrap and tests -->
+        <const name="TESTS_EXTRA_VERBOSE_LOG" value="1"/>
+        <!-- Magento mode for tests execution. Possible values are "default", "developer" and "production". -->
+        <const name="TESTS_MAGENTO_MODE" value="developer"/>
+        <!-- Minimum error log level to listen for. Possible values: -1 ignore all errors, and level constants form http://tools.ietf.org/html/rfc5424 standard -->
+        <const name="TESTS_ERROR_LOG_LISTENER_LEVEL" value="-1"/>
+        <!-- Connection parameters for MongoDB library tests -->
+        <!--<const name="MONGODB_CONNECTION_STRING" value="mongodb://localhost:27017"/>-->
+        <!--<const name="MONGODB_DATABASE_NAME" value="magento_integration_tests"/>-->
+    </php>
+    <!-- Test listeners -->
+    <listeners>
+        <listener class="Magento\TestFramework\Event\PhpUnit"/>
+        <listener class="Magento\TestFramework\ErrorLog\Listener"/>
+    </listeners>
+</phpunit>

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A module for managing scheduled cron jobs from magento's admin panel",
     "require": {
         "php": "~5.6.5|7.0.2|7.0.4|~7.0.6|~7.1.0",
-        "magento/framework": "~101.0.0"
+        "magento/framework": "~100.3.0-dev|~101.0.0"
     },
     "type": "magento2-module",
     "license": [


### PR DESCRIPTION
### Add configuration for travis builds
The current config runs tests in php-7.0 and php-7.1. Within each php version the tests run with Magento 2.2.2, 2.2-develop, and 2.3-develop. The develop version of `magento/framework` for 2.3-develop was added to `composer.json` to facilitate this. Right now only integration tests are configured, since there are no unit tests. 

### Integration tests
These are fairly basic and not comprehensive, but it's a start.