### PR TITLE
Composition Over Inheritance 

### DIFF
--- a/Console/Command/Runjob.php
+++ b/Console/Command/Runjob.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EthanYehuda\CronjobManager\Command;
+namespace EthanYehuda\CronjobManager\Console\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Console/Command/Showjobs.php
+++ b/Console/Command/Showjobs.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EthanYehuda\CronjobManager\Command;
+namespace EthanYehuda\CronjobManager\Console\Command;
 
 use Magento\Framework\App\Area;
 use Symfony\Component\Console\Command\Command;

--- a/Controller/Adminhtml/Config/job/Run.php
+++ b/Controller/Adminhtml/Config/job/Run.php
@@ -2,7 +2,7 @@
 
 namespace EthanYehuda\CronjobManager\Controller\Adminhtml\Config\Job;
 
-use EthanYehuda\CronjobManager\Model\Manager;
+use Magento\Cron\Observer\ProcessCronQueueObserver;
 
 class Run extends \Magento\Backend\App\Action
 {
@@ -12,9 +12,9 @@ class Run extends \Magento\Backend\App\Action
     protected $resultPageFactory;
     
     /**
-     * @var Manager
+     * @var ProcessCronQueueObserver
      */
-    protected $cronJobManager;
+    protected $cronQueue;
     
     /**
      * @var \Magento\Framework\Event\Observer
@@ -31,11 +31,11 @@ class Run extends \Magento\Backend\App\Action
         \Magento\Framework\View\Result\PageFactory $resultPageFactory,
         \Magento\Backend\App\Action\Context $context,
         \Magento\Framework\Event\ObserverFactory $observerFactory,
-        Manager $cronJobManager
+        ProcessCronQueueObserver $cronQueue
     ) {
         parent::__construct($context);
         $this->resultPageFactory = $resultPageFactory;
-        $this->cronJobManager = $cronJobManager;
+        $this->cronQueue= $cronQueue;
         $this->observer = $observerFactory->create('Magento\Framework\Event\Observer');
     }
     
@@ -56,7 +56,7 @@ class Run extends \Magento\Backend\App\Action
     public function execute()
     {
         try {
-            $this->cronJobManager->execute($this->observer);
+            $this->cronQueue->execute($this->observer);
         } catch (\Magento\Framework\Exception\CronException $e) {
             $this->getMessageManager()->addErrorMessage($e->getMessage());
             $this->_redirect('*/config/');

--- a/Helper/Processor.php
+++ b/Helper/Processor.php
@@ -1,0 +1,237 @@
+<?php
+
+
+namespace EthanYehuda\CronjobManager\Helper;
+
+use EthanYehuda\CronjobManager\Model\Cron\InstanceFactory as CronInstanceFactory;
+use Magento\Cron\Observer\ProcessCronQueueObserver;
+use Magento\Cron\Model\Schedule;
+use Magento\Cron\Model\ScheduleFactory;
+use Magento\Framework\App\CacheInterface;
+use Magento\Cron\Model\ConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Psr\Log\LoggerInterface;
+
+class Processor
+{
+    /**
+     * @var CronInstanceFactory
+     */
+    private $cronInstanceFactory;
+    
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+    
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+    /**
+     * @var ScheduleFactory
+     */
+    private $scheduleFactory;
+
+    /**
+     * @var DateTime
+     */
+    private $dateTime;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        CronInstanceFactory $cronInstanceFactory,
+        ScheduleFactory $scheduleFactory,
+        CacheInterface $cache,
+        ConfigInterface $config,
+        ScopeConfigInterface $scopeConfig,
+        DateTime $dateTime,
+        LoggerInterface $logger
+    ) {
+        $this->cronInstanceFactory = $cronInstanceFactory;
+        $this->scheduleFactory = $scheduleFactory;
+        $this->cache = $cache;
+        $this->config = $config;
+        $this->scopeConfig = $scopeConfig;
+        $this->dateTime = $dateTime;
+        $this->logger = $logger;
+    }
+
+    public function runJob($scheduledTime, $currentTime, $jobConfig, $schedule, $groupId)
+    {
+        $jobCode = $schedule->getJobCode();
+        $scheduleLifetime = $this->getCronGroupConfigurationValue(
+                $groupId,
+                ProcessCronQueueObserver::XML_PATH_SCHEDULE_LIFETIME
+            );
+        
+        $scheduleLifetime = $scheduleLifetime * ProcessCronQueueObserver::SECONDS_IN_MINUTE;
+        if ($scheduledTime < $currentTime - $scheduleLifetime) {
+            $schedule->setStatus(Schedule::STATUS_MISSED);
+            throw new \Exception(sprintf(
+                    'Cron Job %s is missed at %s',
+                    $jobCode, 
+                    $schedule->getScheduledAt()
+                ));
+        }
+        if (!isset($jobConfig['instance'], $jobConfig['method'])) {
+            $schedule->setStatus(Schedule::STATUS_ERROR);
+            throw new \Exception('No callbacks found');
+        }
+        
+        // dynamically create cron instances
+        $model = $this->cronInstanceFactory->create($jobConfig['instance']);
+        $callback = [$model, $jobConfig['method']];
+        if (!is_callable($callback)) {
+            $schedule->setStatus(Schedule::STATUS_ERROR);
+            throw new \Exception(
+                sprintf('Invalid callback: %s::%s can\'t be called', $jobConfig['instance'], $jobConfig['method'])
+            );
+        }
+        $schedule->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp()))->save();
+
+        try {
+            $this->logger->info(sprintf('Cron Job %s is run', $jobCode));
+            call_user_func_array($callback, [$schedule]);
+        } catch (\Throwable $e) {
+            $schedule->setStatus(Schedule::STATUS_ERROR);
+            $this->logger->error(sprintf(
+                'Cron Job %s has an error: %s. Statistics: %s',
+                $jobCode,
+                $e->getMessage()
+            ));
+            if (!$e instanceof \Exception) {
+                $e = new \RuntimeException(
+                    'Error when running a cron job',
+                    0,
+                    $e
+                );
+            }
+            throw $e;
+        }
+        
+        $schedule->setStatus(Schedule::STATUS_SUCCESS)->setFinishedAt(strftime(
+            '%Y-%m-%d %H:%M:%S',
+            $this->dateTime->gmtTimestamp()
+        ));
+        $this->logger->info(sprintf(
+            'Cron Job %s is successfully finished',
+            $jobCode
+        ));
+    }
+    
+    public function cleanupJobs($groupId)
+    {
+        $currentTime = $this->dateTime->gmtTimestamp();
+            
+        $this->cache->save(
+                $this->dateTime->gmtTimestamp(),
+                ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . $groupId,
+                ['crontab'],
+                null
+            );
+        
+        $this->cleanupDisabledJobs($groupId);
+        $historySuccess = (int)$this->getCronGroupConfigurationValue(
+                $groupId,
+                ProcessCronQueueObserver::XML_PATH_HISTORY_SUCCESS
+            );
+        $historyFailure = (int)$this->getCronGroupConfigurationValue(
+            $groupId,
+            ProcessCronQueueObserver::XML_PATH_HISTORY_FAILURE
+            );
+        $historyLifetimes = [
+            Schedule::STATUS_SUCCESS => 
+                $historySuccess * ProcessCronQueueObserver::SECONDS_IN_MINUTE,
+            Schedule::STATUS_MISSED => 
+                $historyFailure * ProcessCronQueueObserver::SECONDS_IN_MINUTE,
+            Schedule::STATUS_ERROR => 
+                $historyFailure * ProcessCronQueueObserver::SECONDS_IN_MINUTE,
+            Schedule::STATUS_PENDING => 
+                max($historyFailure, $historySuccess) * ProcessCronQueueObserver::SECONDS_IN_MINUTE,
+        ];
+        
+        $jobs = $this->config->getJobs()[$groupId];
+        $scheduleResource = $this->scheduleFactory->create()->getResource();
+        $connection = $scheduleResource->getConnection();
+        $count = 0;
+        foreach ($historyLifetimes as $time) {
+            $count += $connection->delete(
+                $scheduleResource->getMainTable(),
+                [
+                    'status = ?' => Schedule::STATUS_PENDING,
+                    'job_code in (?)' => array_keys($jobs),
+                    'created_at < ?' => $connection->formatDate($currentTime - $time)
+                ]
+                );
+        }
+        if ($count) {
+            $this->logger->info(sprintf('%d cron jobs were cleaned', $count));
+        }
+    }
+
+    private function cleanupDisabledJobs($groupId)
+    {
+        $jobs = $this->config->getJobs();
+        $jobsToCleanup = [];
+        foreach ($jobs[$groupId] as $jobCode => $jobConfig) {
+            if (!$this->getCronExpression($jobConfig)) {
+                /** @var \Magento\Cron\Model\ResourceModel\Schedule $scheduleResource */
+                $jobsToCleanup[] = $jobCode;
+            }
+        }
+        
+        if (count($jobsToCleanup) > 0) {
+            $scheduleResource = $this->scheduleFactory->create()->getResource();
+            $count = $scheduleResource->getConnection()->delete(
+                $scheduleResource->getMainTable(),
+                [
+                    'status = ?' => Schedule::STATUS_PENDING,
+                    'job_code in (?)' => $jobsToCleanup,
+                ]
+            );
+            $this->logger->info(sprintf('%d cron jobs were cleaned', $count));
+        }
+    }
+
+    private function getCronExpression($jobConfig)
+    {
+        $cronExpression = null;
+        if (isset($jobConfig['config_path'])) {
+            $cronExpression = $this->getConfigSchedule($jobConfig) ?: null;
+        }
+        if (!$cronExpression) {
+            if (isset($jobConfig['schedule'])) {
+                $cronExpression = $jobConfig['schedule'];
+            }
+        }
+        return $cronExpression;
+    }
+    
+    private function getConfigSchedule($jobConfig)
+    {
+        $cronExpr = $this->scopeConfig->getValue(
+                $jobConfig['config_path'],
+                ScopeInterface::SCOPE_STORE
+            );
+        return $cronExpr;
+    }
+ 
+    private function getCronGroupConfigurationValue($groupId, $path)
+    {
+        return $this->scopeConfig->getValue(
+                'system/cron/' . $groupId . '/' . $path,
+                ScopeInterface::SCOPE_STORE
+            );
+    }
+}

--- a/Model/Cron/InstanceFactory.php
+++ b/Model/Cron/InstanceFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Model factory
+ */
+namespace EthanYehuda\CronjobManager\Model\Cron;
+
+use Magento\Framework\ObjectManagerInterface;
+
+class InstanceFactory
+{
+    /**
+     * Object Manager
+     *
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+    
+    public function create($className)
+    {
+        $cronInstance = $this->objectManager->create($className);
+        if (!is_object($cronInstance)) {
+            throw new \Magento\Framework\Exception\LocalizedException(
+                __('%1 doesn\'t exist in the system', $className)
+                );
+        }
+        
+        return $cronInstance;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -16,8 +16,8 @@
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">
-                <item name="ethanyehuda_cronjobmanager_command_showjobs" xsi:type="object">EthanYehuda\CronjobManager\Command\Showjobs</item>
-                <item name="ethanyehuda_cronjobmanager_command_runjob" xsi:type="object">EthanYehuda\CronjobManager\Command\Runjob</item>
+                <item name="ethanyehuda_cronjobmanager_command_showjobs" xsi:type="object">EthanYehuda\CronjobManager\Console\Command\Showjobs</item>
+                <item name="ethanyehuda_cronjobmanager_command_runjob" xsi:type="object">EthanYehuda\CronjobManager\Console\Command\Runjob</item>
             </argument>
         </arguments>
     </type>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="EthanYehuda_CronjobManager" setup_version="1.3.1" >
+    <module name="EthanYehuda_CronjobManager" setup_version="1.3.2" >
     	<sequence>
             <module name="Magento_Cron"/>
         </sequence>


### PR DESCRIPTION
The goal of this PR is to remove the inheritance of Magento's ProcessCronQueueObserver.

In future versions of Magento, the methods the Cron Job Manager previously relied on may be removed.

Case and point: `ProcessCronQueueObserver::_cleanup()` is no longer in [2.2.4's version](https://github.com/magento/magento2/blob/2.2.4-preview/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php) of this class.

The Processor will be a drop in replacement of the methods inherited from ProcessCronQueueObserver, which now gives the manager power to control **how** methods are run.

Also, we moved the commands from Command to Console to follow convention.