### PR TITLE
Keep track of PID and clean up "lost" processes

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Helper;
+
+class Config
+{
+    const PATH_CLEAN_RUNNING = "system/cron_manager/clean_running_schedule";
+}

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -4,5 +4,5 @@ namespace EthanYehuda\CronjobManager\Helper;
 
 class Config
 {
-    const PATH_CLEAN_RUNNING = "system/cron_manager/clean_running_schedule";
+    const PATH_CLEAN_RUNNING = "system/cron_job_manager/clean_running_schedule";
 }

--- a/Observer/CleanRunningJobsObserver.php
+++ b/Observer/CleanRunningJobsObserver.php
@@ -2,6 +2,7 @@
 
 namespace EthanYehuda\CronjobManager\Observer;
 
+use EthanYehuda\CronjobManager\Helper\Config;
 use Magento\Cron\Model\ResourceModel\Schedule\CollectionFactory;
 use Magento\Cron\Model\Schedule;
 use Magento\Framework\Event\Observer;
@@ -15,23 +16,33 @@ class CleanRunningJobsObserver implements ObserverInterface
     /** @var \Magento\Cron\Model\ResourceModel\Schedule */
     private $resourceModel;
 
+    /** @var \Magento\Framework\App\Config\ScopeConfigInterface */
+    private $scopeConfig;
+
     public function __construct(
         CollectionFactory $collectionFactory,
-        \Magento\Cron\Model\ResourceModel\Schedule $resourceModel
+        \Magento\Cron\Model\ResourceModel\Schedule $resourceModel,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
     ) {
         $this->collectionFactory = $collectionFactory;
         $this->resourceModel = $resourceModel;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
-     * Find all jobs in status "running" (according to db), and check if the process is alive.
-     * If not, set status to error, with the message "Process went away"
+     * If this feature is active, Find all jobs in status "running" (according to db),
+     * and check if the process is alive. If not, set status to error, with the message
+     * "Process went away"
      *
      * @param \Magento\Framework\Event\Observer $observer
      * @throws \Magento\Framework\Exception\AlreadyExistsException
      */
     public function execute(Observer $observer)
     {
+        if (!$this->scopeConfig->getValue(Config::PATH_CLEAN_RUNNING)) {
+            return;
+        }
+
         /** @var \Magento\Cron\Model\ResourceModel\Schedule\Collection $collection */
         $collection = $this->collectionFactory->create();
 

--- a/Observer/CleanRunningJobsObserver.php
+++ b/Observer/CleanRunningJobsObserver.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Observer;
+
+use Magento\Cron\Model\ResourceModel\Schedule\CollectionFactory;
+use Magento\Cron\Model\Schedule;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class CleanRunningJobsObserver implements ObserverInterface
+{
+    /** @var \Magento\Cron\Model\ResourceModel\Schedule\CollectionFactory */
+    private $collectionFactory;
+
+    /** @var \Magento\Cron\Model\ResourceModel\Schedule */
+    private $resourceModel;
+
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        \Magento\Cron\Model\ResourceModel\Schedule $resourceModel
+    ) {
+        $this->collectionFactory = $collectionFactory;
+        $this->resourceModel = $resourceModel;
+    }
+
+    /**
+     * Find all jobs in status "running" (according to db), and check if the process is alive.
+     * If not, set status to error, with the message "Process went away"
+     *
+     * @param \Magento\Framework\Event\Observer $observer
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var \Magento\Cron\Model\ResourceModel\Schedule\Collection $collection */
+        $collection = $this->collectionFactory->create();
+
+        $collection->addFieldToFilter("status", Schedule::STATUS_RUNNING);
+
+        /** @var Schedule $schedule */
+        foreach ($collection->getItems() as $schedule) {
+            if ($this->isPidAlive($schedule->getData("pid"))) {
+                continue;
+            }
+
+            $messages = [];
+            if ($schedule->getMessages()) {
+                $messages[] = $schedule->getMessages();
+            }
+
+            $messages[] = "Process went away";
+
+            $schedule
+                ->setStatus(Schedule::STATUS_ERROR)
+                ->setMessages(join("\n", $messages))
+            ;
+
+            $this->resourceModel->save($schedule);
+        }
+    }
+
+    /**
+     * @param int $pid
+     * @return boolean
+     */
+    private function isPidAlive($pid)
+    {
+        if (file_exists("/proc/" . \intval($pid))) {
+            return true;
+        }
+
+        // todo: add support for other os than linux?
+        // https://stackoverflow.com/questions/9874331/how-to-check-whether-specified-pid-is-currently-running-without-invoking-ps-from
+
+        return false;
+    }
+}

--- a/Observer/CleanRunningJobsObserver.php
+++ b/Observer/CleanRunningJobsObserver.php
@@ -3,8 +3,10 @@
 namespace EthanYehuda\CronjobManager\Observer;
 
 use EthanYehuda\CronjobManager\Helper\Config;
-use Magento\Cron\Model\ResourceModel\Schedule\CollectionFactory;
 use Magento\Cron\Model\Schedule;
+use Magento\Cron\Model\ResourceModel\Schedule as ScheduleResource;
+use Magento\Cron\Model\ResourceModel\Schedule\CollectionFactory;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 
@@ -21,8 +23,8 @@ class CleanRunningJobsObserver implements ObserverInterface
 
     public function __construct(
         CollectionFactory $collectionFactory,
-        \Magento\Cron\Model\ResourceModel\Schedule $resourceModel,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+        ScheduleResource $resourceModel,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->collectionFactory = $collectionFactory;
         $this->resourceModel = $resourceModel;
@@ -63,8 +65,7 @@ class CleanRunningJobsObserver implements ObserverInterface
 
             $schedule
                 ->setStatus(Schedule::STATUS_ERROR)
-                ->setMessages(join("\n", $messages))
-            ;
+                ->setMessages(join("\n", $messages));
 
             $this->resourceModel->save($schedule);
         }
@@ -76,12 +77,9 @@ class CleanRunningJobsObserver implements ObserverInterface
      */
     private function isPidAlive($pid)
     {
-        if (file_exists("/proc/" . \intval($pid))) {
+        if (file_exists("/proc/" . intval($pid))) {
             return true;
         }
-
-        // todo: add support for other os than linux?
-        // https://stackoverflow.com/questions/9874331/how-to-check-whether-specified-pid-is-currently-running-without-invoking-ps-from
 
         return false;
     }

--- a/Plugin/Cron/Model/SchedulePlugin.php
+++ b/Plugin/Cron/Model/SchedulePlugin.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Plugin\Cron\Model;
+
+class SchedulePlugin
+{
+    /**
+     * If the return from @see \Magento\Cron\Model\Schedule::tryLockJob is
+     * true, the job has started in THIS process, if it returns false, it has
+     * not started, probably because it was already running.
+     *
+     * @param \Magento\Cron\Model\Schedule $subject
+     * @param $return
+     * @return boolean
+     */
+    public function afterTryLockJob(\Magento\Cron\Model\Schedule $subject, $return)
+    {
+        if ($return) {
+            $subject->setData("pid", \getmypid());
+        }
+
+        return $return;
+    }
+}

--- a/Plugin/Cron/Model/SchedulePlugin.php
+++ b/Plugin/Cron/Model/SchedulePlugin.php
@@ -2,13 +2,16 @@
 
 namespace EthanYehuda\CronjobManager\Plugin\Cron\Model;
 
+use Magento\Cron\Model\Schedule;
+use Magento\Cron\Model\ResourceModel\Schedule as ScheduleResource;
+
 class SchedulePlugin
 {
     /** @var \Magento\Cron\Model\ResourceModel\Schedule */
     private $resourceModel;
 
     public function __construct(
-        \Magento\Cron\Model\ResourceModel\Schedule $resourceModel
+        ScheduleResource $resourceModel
     ) {
         $this->resourceModel = $resourceModel;
     }
@@ -23,10 +26,10 @@ class SchedulePlugin
      * @return boolean
      * @throws \Magento\Framework\Exception\AlreadyExistsException
      */
-    public function afterTryLockJob(\Magento\Cron\Model\Schedule $subject, $return)
+    public function afterTryLockJob(Schedule $subject, $return)
     {
         if ($return) {
-            $subject->setData("pid", \getmypid());
+            $subject->setData("pid", getmypid());
             $this->resourceModel->save($subject); // Save A.S.A.P, in case the process is killed
         }
 

--- a/Plugin/Cron/Model/SchedulePlugin.php
+++ b/Plugin/Cron/Model/SchedulePlugin.php
@@ -4,6 +4,15 @@ namespace EthanYehuda\CronjobManager\Plugin\Cron\Model;
 
 class SchedulePlugin
 {
+    /** @var \Magento\Cron\Model\ResourceModel\Schedule */
+    private $resourceModel;
+
+    public function __construct(
+        \Magento\Cron\Model\ResourceModel\Schedule $resourceModel
+    ) {
+        $this->resourceModel = $resourceModel;
+    }
+
     /**
      * If the return from @see \Magento\Cron\Model\Schedule::tryLockJob is
      * true, the job has started in THIS process, if it returns false, it has
@@ -12,11 +21,13 @@ class SchedulePlugin
      * @param \Magento\Cron\Model\Schedule $subject
      * @param $return
      * @return boolean
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
      */
     public function afterTryLockJob(\Magento\Cron\Model\Schedule $subject, $return)
     {
         if ($return) {
             $subject->setData("pid", \getmypid());
+            $this->resourceModel->save($subject); // Save A.S.A.P, in case the process is killed
         }
 
         return $return;

--- a/Plugin/Cron/Observer/ProcessCronQueueObserverPlugin.php
+++ b/Plugin/Cron/Observer/ProcessCronQueueObserverPlugin.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Plugin\Cron\Observer;
+
+use Magento\Cron\Observer\ProcessCronQueueObserver;
+use Magento\Framework\Event\Observer;
+
+class ProcessCronQueueObserverPlugin
+{
+    /** @var \Magento\Cron\Model\ResourceModel\Schedule */
+    private $resourceModel;
+
+    /** @var \Magento\Framework\Event\Manager */
+    private $eventManager;
+
+    public function __construct(
+        \Magento\Cron\Model\ResourceModel\Schedule $resourceModel,
+        \Magento\Framework\Event\Manager $eventManager
+    ) {
+        $this->resourceModel = $resourceModel;
+        $this->eventManager = $eventManager;
+    }
+
+    /**
+     * Dispatch an event before cron processing begin
+     * @see \Magento\Cron\Observer\ProcessCronQueueObserver::execute()
+     *
+     * @param \Magento\Cron\Observer\ProcessCronQueueObserver $subject
+     * @param \Magento\Framework\Event\Observer $observer
+     * @return array
+     */
+    public function beforeExecute(ProcessCronQueueObserver $subject, Observer $observer)
+    {
+        $this->eventManager->dispatch("process_cron_queue_before", ["queue" => $subject]);
+
+        return [$observer];
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Setup;
+
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+use Magento\Framework\DB\Ddl\Table;
+
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+
+    /** @var SchemaSetupInterface */
+    private $setup;
+
+    /** @var ModuleContextInterface */
+    private $context;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function upgrade(
+        SchemaSetupInterface $setup,
+        ModuleContextInterface $context
+    ) {
+        $this->setup = $setup;
+        $this->context = $context;
+
+        $this->setup->startSetup();
+
+        if (version_compare($context->getVersion(), '1.6.0') < 0) {
+            $this->addPidToSchedule();
+        }
+
+        $this->setup->endSetup();
+    }
+
+    /**
+     * Add column to cron_schedule to keep track of the processes running on the server
+     */
+    public function addPidToSchedule()
+    {
+        $this->setup->getConnection()->addColumn(
+            $this->setup->getTable("cron_schedule"),
+            "pid",
+            [
+                "type" => Table::TYPE_INTEGER,
+                "comment" => "Process id (pid) on the server",
+                "nullable" => true,
+                "default" => null,
+                "after" => "status",
+                "unsigned" => true
+            ]
+        );
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="system">
+            <group id="cron_manager" translate="label" showInDefault="1" showInWebsite="0" showInStore="0" sortOrder="17">
+                <label>Cron Manager</label>
+                <field id="clean_running_schedule" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Clean schedule of missing processes</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>If a process has status "running", but there is no corresponding process alive on the server, the job will be set to "error". This prevents buildup of false "running" jobs.</comment>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -2,8 +2,8 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
         <section id="system">
-            <group id="cron_manager" translate="label" showInDefault="1" showInWebsite="0" showInStore="0" sortOrder="17">
-                <label>Cron Manager</label>
+            <group id="cron_job_manager" translate="label" showInDefault="1" showInWebsite="0" showInStore="0" sortOrder="17">
+                <label>Cron Job Manager</label>
                 <field id="clean_running_schedule" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Clean schedule of missing processes</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -3,9 +3,9 @@
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <system>
-            <cron_manager>
+            <cron_job_manager>
                 <clean_running_schedule>1</clean_running_schedule>
-            </cron_manager>
+            </cron_job_manager>
         </system>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <system>
+            <cron_manager>
+                <clean_running_schedule>1</clean_running_schedule>
+            </cron_manager>
+        </system>
+    </default>
+</config>

--- a/etc/crontab/di.xml
+++ b/etc/crontab/di.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Cron\Observer\ProcessCronQueueObserver">
-        <plugin name="ethanyehuda_cronjobmanager_clean_running_jobs" type="\EthanYehuda\CronjobManager\Plugin\Cron\Observer\ProcessCronQueueObserverPlugin" />
+        <plugin name="ethanyehuda_cronjobmanager_clean_running_jobs" type="EthanYehuda\CronjobManager\Plugin\Cron\Observer\ProcessCronQueueObserverPlugin" />
     </type>
 </config>

--- a/etc/crontab/di.xml
+++ b/etc/crontab/di.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Cron\Observer\ProcessCronQueueObserver">
+        <plugin name="ethanyehuda_cronjobmanager_clean_running_jobs" type="\EthanYehuda\CronjobManager\Plugin\Cron\Observer\ProcessCronQueueObserverPlugin" />
+    </type>
+</config>

--- a/etc/crontab/events.xml
+++ b/etc/crontab/events.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="process_cron_queue_before">
-        <observer name="ethanyehuda_cronjobmanager_clean_running_jobs" instance="\EthanYehuda\CronjobManager\Observer\CleanRunningJobsObserver" />
+        <observer name="ethanyehuda_cronjobmanager_clean_running_jobs" instance="EthanYehuda\CronjobManager\Observer\CleanRunningJobsObserver" />
     </event>
 </config>

--- a/etc/crontab/events.xml
+++ b/etc/crontab/events.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="process_cron_queue_before">
+        <observer name="ethanyehuda_cronjobmanager_clean_running_jobs" instance="\EthanYehuda\CronjobManager\Observer\CleanRunningJobsObserver" />
+    </event>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -22,6 +22,6 @@
         </arguments>
     </type>
     <type name="Magento\Cron\Model\Schedule">
-        <plugin name="ethanyehuda_cronjobmanager_set_pid" type="\EthanYehuda\CronjobManager\Plugin\Cron\Model\SchedulePlugin" />
+        <plugin name="ethanyehuda_cronjobmanager_set_pid" type="EthanYehuda\CronjobManager\Plugin\Cron\Model\SchedulePlugin" />
     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -21,4 +21,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Cron\Model\Schedule">
+        <plugin name="ethanyehuda_cronjobmanager_set_pid" type="\EthanYehuda\CronjobManager\Plugin\Cron\Model\SchedulePlugin" />
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="EthanYehuda_CronjobManager" setup_version="1.5.1" >
+    <module name="EthanYehuda_CronjobManager" setup_version="1.6.0" >
     	<sequence>
             <module name="Magento_Cron"/>
         </sequence>


### PR DESCRIPTION
## Code
Solves one requirement of https://github.com/Ethan3600/magento2-CronjobManager/issues/19 (Track PID of each cron job).

Also adds another feature, cleaning of jobs in cron_schedude table that has status "running", but the process is missing from the current system. There is a system config to disable this behavior in admin.

Seeing that this is a new feature added, I bumped the version to 1.6.0. I am fine with changing this if you wish.

## Background
In our environment the cron process runs on a node that can be shut down and moved quite randomly, causing jobs to die mid-way through. This leaves a process in "running" status forever. It also stops any following jobs from running, except the scheduler. So that keeps adding all future jobs to the list, a few thousand per day. And that in turn puts enormous load on our DB server.

I hope you'll accept this pull request, even though we did not discuss it first, I simply needed our issue solved right away, and seeing that this was on the roadmap anyway it seemed wrong to put it in it's own module.

//Andre Klang
PS: Thanks for your great module!