### PR TITLE
Timeline Performance boost: Round 2

### DIFF
--- a/Ui/DataProvider/TimelineDataProvider.php
+++ b/Ui/DataProvider/TimelineDataProvider.php
@@ -7,7 +7,7 @@ use Magento\Ui\DataProvider\AbstractDataProvider;
 
 class TimelineDataProvider extends AbstractDataProvider
 {
-    const MAX_PAGE_SIZE = 37500;
+    const MAX_PAGE_SIZE = 35000;
 
     private $loadedData;
 

--- a/Ui/DataProvider/TimelineDataProvider.php
+++ b/Ui/DataProvider/TimelineDataProvider.php
@@ -7,6 +7,8 @@ use Magento\Ui\DataProvider\AbstractDataProvider;
 
 class TimelineDataProvider extends AbstractDataProvider
 {
+    const MAX_PAGE_SIZE = 37500;
+
     private $loadedData;
 
     /**
@@ -38,15 +40,27 @@ class TimelineDataProvider extends AbstractDataProvider
             return $this->loadedData;
         }
 
-        $collectionSize = $this->collection->getSize();
+        $firstHour = null;
+        $lastHour = null;
+
+        $this->collection
+            ->addOrder('scheduled_at', 'DESC')
+            ->addOrder('job_code', 'ASC')
+            ->setPageSize(self::MAX_PAGE_SIZE)
+            ->addFieldToFilter(
+                'scheduled_at', [
+                    'gt' => date(
+                        'Y-m-d H:m:s',
+                        strtotime(date('Y-m-d H:m:s') . ' -7 day')
+                    )
+                ]
+            );
+
+        $collectionSize = $this->collection->count();
         if($collectionSize < 1) {
             return [];
         }
 
-        $firstHour = null;
-        $lastHour = null;
-
-        $this->collection->addOrder('job_code', 'ASC');
         foreach ($this->collection->getItems() as $item) {
             $this->loadedData[$item->getJobCode()][] = $item->getData();
             

--- a/Ui/DataProvider/TimelineDataProvider.php
+++ b/Ui/DataProvider/TimelineDataProvider.php
@@ -38,7 +38,8 @@ class TimelineDataProvider extends AbstractDataProvider
             return $this->loadedData;
         }
 
-        if($this->collection->getSize() < 1) {
+        $collectionSize = $this->collection->getSize();
+        if($collectionSize < 1) {
             return [];
         }
 
@@ -58,6 +59,7 @@ class TimelineDataProvider extends AbstractDataProvider
         }
 
         array_unshift($this->loadedData, [
+            'total' => $collectionSize, 
             'range' => $this->getRange($firstHour, $lastHour)
         ]);
 

--- a/view/adminhtml/layout/cronjobmanager_timeline_index.xml
+++ b/view/adminhtml/layout/cronjobmanager_timeline_index.xml
@@ -5,6 +5,8 @@
         <css src="EthanYehuda_CronjobManager::css/source/_module.css"/>
     </head>
     <referenceBlock name="content">
+        <block name="ethanyehuda_cronjobmanager_dom_observer_disabler"
+            template="EthanYehuda_CronjobManager::timeline.phtml"/>
         <uiComponent name="cronjobmanager_timeline"/>
     </referenceBlock>
 </page>

--- a/view/adminhtml/requirejs-config.js
+++ b/view/adminhtml/requirejs-config.js
@@ -1,5 +1,10 @@
 var config = {
 	paths: {
         'cronjobManager/template': 'EthanYehuda_CronjobManager/templates'
+    },
+    shim: {
+        'EthanYehuda/js/timeline/timeline': {
+            'deps': ['EthanYehuda/js/lib/knockout/bindings/virtual-foreach']
+        }
     }
 };

--- a/view/adminhtml/requirejs-config.js
+++ b/view/adminhtml/requirejs-config.js
@@ -3,8 +3,8 @@ var config = {
         'cronjobManager/template': 'EthanYehuda_CronjobManager/templates'
     },
     shim: {
-        'EthanYehuda/js/timeline/timeline': {
-            'deps': ['EthanYehuda/js/lib/knockout/bindings/virtual-foreach']
+        'EthanYehuda_CronjobManager/js/timeline/timeline': {
+            'deps': ['EthanYehuda_CronjobManager/js/lib/knockout/bindings/virtual-foreach']
         }
     }
 };

--- a/view/adminhtml/templates/timeline.phtml
+++ b/view/adminhtml/templates/timeline.phtml
@@ -1,3 +1,12 @@
-<?php
-
-// ...so much empty
+<script type="text/javascript">
+(function() {
+var config = {
+    map: {
+        '*': {
+            'Magento_Ui/js/lib/view/utils/dom-observer': 'EthanYehuda_CronjobManager/js/disableDomObserver'
+        }
+    }
+};
+require.config(config);
+})();
+</script>

--- a/view/adminhtml/ui_component/cronjobmanager_timeline.xml
+++ b/view/adminhtml/ui_component/cronjobmanager_timeline.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" class="EthanYehuda\CronjobManager\Component\Timeline">
 	<argument name="data" xsi:type="array">
+        <item name="spinner" xsi:type="string">timeline_container</item>
 		<item name="js_config" xsi:type="array">
 			<item name="provider" xsi:type="string">cronjobmanager_timeline.cronjobmanager_timeline_data_source</item>
 			<item name="deps" xsi:type="string">cronjobmanager_timeline.cronjobmanager_timeline_data_source</item>
 		</item>
-		<item name="spinner" xsi:type="string">timeline_container</item>
 		<item name="template" xsi:type="string">templates/container</item>
 		<item name="buttons" xsi:type="array">
 			<item name="back" xsi:type="array">
@@ -36,6 +36,7 @@
 	</dataSource>
 	<container name="timeline_container">
 		<argument name="data" xsi:type="array">
+            <item name="spinner" xsi:type="string">timeline_panel</item>
 			<item name="config" xsi:type="array">
 				<item name="component" xsi:type="string">EthanYehuda_CronjobManager/js/timeline/timeline</item>
 			</item>

--- a/view/adminhtml/web/js/disableDomObserver.js
+++ b/view/adminhtml/web/js/disableDomObserver.js
@@ -1,0 +1,1 @@
+// ...nothing to see here

--- a/view/adminhtml/web/js/lib/knockout/bindings/bootstrapExt.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/bootstrapExt.js
@@ -1,0 +1,10 @@
+define([
+    'underscore',
+    'Magento_Ui/js/lib/knockout/bindings/bootstrap',
+    'require',
+    './virtual-foreach'
+], function (_, bootstrap, require) {
+   return _.extend(bootstrap, {
+       virtualForEach: require('./virtual-foreach')
+   }) 
+});

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -166,6 +166,7 @@ define([
                             row.el.appendChild(row.frag);
                         }
                     }
+                    window.virtualRegistry = [];
                 }
 
                 function deMaterialize() {

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -23,9 +23,10 @@ define([
      * @param {Object} cron
      * @param {Object} tcOffset - timeline container offset results
      * @param {int} i - iterations in the virtualForEach
+     * @param {Object} - $timelinePanel
      * @return {Object} cronOffset - top and left 
      */
-    var preCalculateOffset = function(viewModel, cron, tcOffset, i) {
+    var preCalculateOffset = function(viewModel, cron, tcOffset, i, $timelinePanel) {
         var cronOffset = {};
 
         /////////////////Vertial Offset/////////////////
@@ -35,7 +36,7 @@ define([
         cronOffset.top = tcOffset.top + rowHeightOffset + rowHoursOffset; 
         ///////////////Horizontal Offset////////////////
         var timeOffset = viewModel.getOffset(cron, true);
-        cronOffset.left = timeOffset + $('.timeline-container__panel').offset().left;
+        cronOffset.left = timeOffset + $timelinePanel.offset().left;
 
         return cronOffset;
     }
@@ -60,6 +61,7 @@ define([
             config.data = ko.observableArray(config.data);
 
             var $timelineCont = $('.timeline-container');
+            var $timelinePanel = $('.timeline-container__panel');
             var tcOffset = $timelineCont.offset();
 
             // record of all materialized rows
@@ -91,7 +93,7 @@ define([
                 for (var i = 0; i < crons.length; i++) {
                     var cron = crons[i];
                     if (!created[cron.schedule_id]) {
-                        var cronOffset = preCalculateOffset(timelineViewModel, cron, tcOffset, index);
+                        var cronOffset = preCalculateOffset(timelineViewModel, cron, tcOffset, index, $timelinePanel);
                         if (isInBounds(cronOffset)) {
                             var cronElement = clone.clone().children();
                             ko.applyBindingsToDescendants(
@@ -112,7 +114,7 @@ define([
 
                 // Deletes all crons that are out of bounds
                 // Object.keys(created).forEach(function(id) {
-                //     var cronOffset = preCalculateOffset(timelineViewModel, created[id].cron, tcOffset, index);
+                //     var cronOffset = preCalculateOffset(timelineViewModel, created[id].cron, tcOffset, index, $timelinePanel);
                 //     if (!isInBounds(cronOffset)) {
                 //         created[id].el.remove();
                 //         delete created[id];

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -1,17 +1,118 @@
+/**
+ * Based on Daniel Earwicker's virtualized scolling
+ * https://smellegantcode.wordpress.com/2012/12/26/virtualized-scrolling-in-knockout-js/
+ */
 define([
     'ko',
+    'jquery',
     'Magento_Ui/js/lib/knockout/template/renderer'
-], function (ko, renderer) {
+], function (ko, $, renderer) {
     'use strict';
 
-        ko.bindingHandlers.virtualForEach = {
+    var simulatedObservable = (function() {
 
-            /**
-             * Binding init callback.
-             */
-            init: function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+    var timer = null;
+    var items = [];
+
+    var check = function() {
+        items = items.filter(function(item) {
+            return !!item.elem.parents('html').length;
+        });
+        if (items.length === 0) {
+            clearInterval(timer);
+            timer = null;
+            return;
+        }
+        items.forEach(function(item) {
+            item.obs(item.getter());
+        });
+    };
+
+    return function(elem, getter) {
+        var obs = ko.observable(getter());
+        items.push({ obs: obs, getter: getter, elem: $(elem) });
+        if (timer === null) {
+            timer = setInterval(check, 100);
+        }
+        return obs;
+    };
+
+    ko.bindingHandlers.virtualForEach = {
+
+        /**
+         * Binding init callback.
+         */
+        init: function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            var clone = $(element).clone();
+            $(element).empty();
+
+            var config = ko.utils.unwrapObservable(valueAccessor());
+            if (config.data == null) {
+                return;
             }
-        };
+            var rowHeight = 40;
+
+            ko.computed(function() {
+                $(element).css({
+                    height: config.data.length * rowHeight
+                });
+            });
+
+            var offset = simulatedObservable(element, function() {
+                return $(element).offset().top;
+            });
+
+            var windowHeight = simulatedObservable(element, function() {
+                return window.innerHeight;
+            });
+
+            var created = {};
+
+            var refresh = function() {
+                var o = offset();
+                var data = config.data;
+                var top = Math.max(0, Math.floor(-o / rowHeight) - 10);
+                var bottom = Math.min(data.length, Math.ceil((-o + windowHeight()) / rowHeight));
+
+                for (var row = top; row < bottom; row++) {
+                    if (!created[row]) {
+                        var rowDiv = $('<div></div>');
+                        rowDiv.css({
+                            position: 'absolute',
+                            height: config.rowHeight,
+                            left: 0,
+                            right: 0,
+                            top: row * config.rowHeight
+                        });
+                        rowDiv.append(clone.clone().children());
+                        ko.applyBindingsToDescendants(context.createChildContext(data[row]), rowDiv[0]);
+                        created[row] = rowDiv;
+                        $(element).append(rowDiv);
+                    }
+                }
+
+                Object.keys(created).forEach(function(rowNum) {
+                    if (rowNum < top || rowNum >= bottom) {
+                        created[rowNum].remove();
+                        delete created[rowNum];
+                    }
+                });
+            };
+
+            config.rows.subscribe(function() {
+                Object.keys(created).forEach(function(rowNum) {
+                    created[rowNum].remove();
+                    delete created[rowNum];
+                });
+                refresh();
+            });
+
+            ko.computed(refresh);
+
+            return { controlsDescendantBindings: true };
+        }
+    };
 
     renderer.addNode('virtualForEach');
+    ko.virtualElements.allowedBindings.virtualForEach = true;
 });

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -60,7 +60,7 @@ define([
             var obs = ko.observable(getter());
             items.push({ obs: obs, getter: getter, elem: $(elem) });
             if (timer === null) {
-                timer = setInterval(check, 100);
+                timer = setInterval(check, 250);
             }
             return obs;
         };
@@ -161,7 +161,7 @@ define([
                 refresh();
             });
 
-            ko.computed(refresh).extend({ rateLimit: 250 });
+            ko.computed(refresh).extend({ rateLimit: 500 });
             return { controlsDescendantBindings: true };
         }
     };

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -109,7 +109,6 @@ define([
              * are currently visible
              */
             var refresh = function() {
-                var index = bindingContext.$data.index;
                 var topBoundry = $(window).scrollTop();
                 var bottomBoundry = topBoundry + $(window).height() + 40;
                 var leftBoundry = tcOffset.left;   

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -99,8 +99,9 @@ define([
                     }
                 });
 
-                Object.keys(created).forEach(function(rowNum) {
-                    if (rowNum < top || rowNum >= bottom) {
+                Object.keys(created).forEach(function(id) {
+                    // can't grab element offset.. 
+                    if (id < top || id >= bottom) {
                         // created[rowNum].remove();
                         // delete created[rowNum];
                     }

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -11,12 +11,6 @@ define([
 ], function (ko, $, renderer, loader, raf) {
     'use strict';
 
-    window.cancelAnimationFrame = window.cancelAnimationFrame
-        || window.mozCancelAnimationFrame
-        || function(requestID) {
-            clearTimeout(requestID);
-        };
-
     window.virtualRegistry = [];
 
    /**

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -184,7 +184,8 @@ define([
                     });
                     Object.keys(window.created).forEach(function(id) {
                         if (window.created[id].remove) {
-                            window.created[id].el.remove();
+                            var node = window.created[id].el[0];
+                            node.parentNode.removeChild(node);
                             delete window.created[id];
                         }
                     });

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -104,8 +104,6 @@ define([
 
             // record of all materialized rows
             var created = {};
-            var animationRef;
-            var prevIndex = -1;
 
             /**
              * Responsible for materializing any cron jobs that
@@ -113,12 +111,6 @@ define([
              */
             var refresh = function() {
                 var index = bindingContext.$data.index;
-                if (animationRef != null && prevIndex > index) {
-                    prevIndex = -1;
-                    cancelAnimationFrame(animationRef);
-                    return;
-                }
-                prevIndex++;
                 var topBoundry = $(window).scrollTop();
                 var bottomBoundry = topBoundry + $(window).height() + 40;
                 var leftBoundry = tcOffset.left;   
@@ -172,7 +164,6 @@ define([
                     isVerticallyInBounds = false;
                     return false;
                 }
-                animationRef = null;
             };
 
             config.data.subscribe(function() {
@@ -180,7 +171,7 @@ define([
                     created[id].el.remove();
                     delete created[id];
                 });
-                animationRef = raf(refresh);
+                raf(refresh);
             });
 
             var windowTimer = null;
@@ -189,9 +180,7 @@ define([
                     clearTimeout(windowTimer);
                 }
                 windowTimer = setTimeout(function() {
-                    if (animationRef == null) { 
-                        animationRef = raf(refresh); 
-                    }
+                    raf(refresh); 
                 }, 1000);
             });
 
@@ -201,13 +190,11 @@ define([
                     clearTimeout(panelTimer);
                 }
                 panelTimer = setTimeout(function() {
-                    if (animationRef == null) { 
-                        animationRef = raf(refresh); 
-                    }
+                    raf(refresh); 
                 }, 1000);
             });
 
-            // animationRef = raf(refresh);
+            // raf(refresh);
             return { controlsDescendantBindings: true };
         }
     };

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -110,9 +110,6 @@ define([
              */
             var refresh = function() {
                 var index = bindingContext.$data.index;
-                if (index === 1) {
-                    loader.get('timeline_container.timeline_panel').show();
-                }
                 var topBoundry = $(window).scrollTop();
                 var bottomBoundry = topBoundry + $(window).height() + 40;
                 var leftBoundry = tcOffset.left;   

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -65,7 +65,7 @@ define([
             // record of all materialized rows
             var created = {};
             var animationRef;
-            var prevIndex = 0;
+            var prevIndex = -1;
 
             /**
              * Responsible for materializing any cron jobs that
@@ -73,8 +73,8 @@ define([
              */
             var refresh = function() {
                 var index = bindingContext.$data.index;
-                if (animationRef != null && prevIndex != null && prevIndex > index) {
-                    prevIndex = 0;
+                if (animationRef != null && prevIndex > index) {
+                    prevIndex = -1;
                     cancelAnimationFrame(animationRef);
                     return;
                 }
@@ -110,13 +110,14 @@ define([
                     }
                 };
 
-                Object.keys(created).forEach(function(id) {
-                    var cronOffset = preCalculateOffset(timelineViewModel, created[id].cron, tcOffset, index);
-                    if (!isInBounds(cronOffset)) {
-                        created[id].el.remove();
-                        delete created[id];
-                    }
-                });
+                // Deletes all crons that are out of bounds
+                // Object.keys(created).forEach(function(id) {
+                //     var cronOffset = preCalculateOffset(timelineViewModel, created[id].cron, tcOffset, index);
+                //     if (!isInBounds(cronOffset)) {
+                //         created[id].el.remove();
+                //         delete created[id];
+                //     }
+                // });
 
                 function isInBounds(cronOffset) {
                     var cTop = cronOffset.top;
@@ -131,6 +132,7 @@ define([
                     isVerticallyInBounds = false;
                     return false;
                 }
+                animationRef = null;
             };
 
             config.data.subscribe(function() {
@@ -138,7 +140,7 @@ define([
                     created[id].el.remove();
                     delete created[id];
                 });
-                raf(refresh);
+                animationRef = raf(refresh);
             });
 
             var windowTimer = null;
@@ -147,8 +149,10 @@ define([
                     clearTimeout(windowTimer);
                 }
                 windowTimer = setTimeout(function() {
-                    animationRef = raf(refresh); 
-                }, 2000);
+                    if (animationRef == null) { 
+                        animationRef = raf(refresh); 
+                    }
+                }, 1000);
             });
 
             var panelTimer = null;
@@ -157,12 +161,14 @@ define([
                     clearTimeout(panelTimer);
                 }
                 panelTimer = setTimeout(function() {
-                    animationRef = raf(refresh); 
-                }, 2000);
+                    if (animationRef == null) { 
+                        animationRef = raf(refresh); 
+                    }
+                }, 1000);
  
             });
 
-            raf(refresh); 
+            raf(refresh);
             return { controlsDescendantBindings: true };
         }
     };

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -212,14 +212,6 @@ define([
                 }
             };
 
-            config.data.subscribe(function() {
-                Object.keys(window.created).forEach(function(id) {
-                    window.created[id].el.remove();
-                    delete window.created[id];
-                });
-                raf(refresh);
-            });
-
             var windowTimer = null;
             $(window).on('scroll', function() {
                 if (windowTimer !== null) {
@@ -227,11 +219,11 @@ define([
                 }
                 windowTimer = setTimeout(function() {
                     raf(refresh); 
-                }, 1000);
+                }, 150);
             });
 
             var panelTimer = null;
-            $timelinePanel.on('scroll mouseup', function() {
+            $timelinePanel.on('scroll', function() {
                 if (panelTimer !== null) {
                     clearTimeout(panelTimer);
                 }

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -1,0 +1,17 @@
+define([
+    'ko',
+    'Magento_Ui/js/lib/knockout/template/renderer'
+], function (ko, renderer) {
+    'use strict';
+
+        ko.bindingHandlers.virtualForEach = {
+
+            /**
+             * Binding init callback.
+             */
+            init: function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            }
+        };
+
+    renderer.addNode('virtualForEach');
+});

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -6,8 +6,9 @@ define([
     'ko',
     'jquery',
     'Magento_Ui/js/lib/knockout/template/renderer',
+    'Magento_Ui/js/lib/spinner',
     'Magento_Ui/js/lib/view/utils/raf'
-], function (ko, $, renderer, raf) {
+], function (ko, $, renderer, loader, raf) {
     'use strict';
 
     window.cancelAnimationFrame = window.cancelAnimationFrame
@@ -96,10 +97,10 @@ define([
             // lets make our data into an observable array
             config.data = ko.observableArray(config.data);
 
+            var index = bindingContext.$data.index;
             var $timelineCont = $('.timeline-container');
             var $timelinePanel = $('.timeline-container__panel');
             var tcOffset = $timelineCont.offset();
-
             // timeline panel offset
             var panelOffset = simulatedObservable($timelinePanel, function() {
                 return $timelinePanel.offset().left;
@@ -115,6 +116,9 @@ define([
              */
             var refresh = function() {
                 var index = bindingContext.$data.index;
+                if (index === 1) {
+                    loader.get('timeline_container.timeline_panel').show();
+                }
                 var topBoundry = $(window).scrollTop();
                 var bottomBoundry = topBoundry + $(window).height() + 40;
                 var leftBoundry = tcOffset.left;   
@@ -152,10 +156,11 @@ define([
                     frag: fragment
                 };
 
-                if (index == totalTasks) {
+                if (index === totalTasks) {
                     raf(function() {
                         materialize();
                         deMaterialize();
+                        loader.get('timeline_container.timeline_panel').hide();
                     });
                 }
 
@@ -235,6 +240,16 @@ define([
                 }, 1000);
             });
 
+            $timelineCont.on('timeline.ready', function() {
+                $(window).trigger('scroll');
+                loader.get('timeline_container.timeline_panel').hide();
+            });
+
+            if (index === totalTasks) {
+                // trigger's materialization after 
+                // the last virtualForEach has run
+                $timelineCont.trigger('timeline.ready');
+            }
             return { controlsDescendantBindings: true };
         }
     };

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -114,7 +114,12 @@ define([
                 var leftBoundry = tcOffset.left;   
                 var rightBoundry = $timelineCont.width() + leftBoundry;
 
-                ko.utils.arrayForEach(config.data(), function(cron) {
+                // flag to check if entire row is in bounds
+                var isVerticallyInBounds = true;
+
+                var crons = config.data();
+                for (var i = 0; i < crons.length; i++) {
+                    var cron = crons[i];
                     if (!created[cron.schedule_id]) {
                         var cronOffset = preCalculateOffset(timelineViewModel, cron, tcOffset, index);
                         if (isInBounds(cronOffset)) {
@@ -129,8 +134,11 @@ define([
                             };
                             $(element).append(cronElement);
                         }
+                        if (!isVerticallyInBounds) {
+                            break;
+                        }
                     }
-                });
+                };
 
                 Object.keys(created).forEach(function(id) {
                     var cronOffset = preCalculateOffset(timelineViewModel, created[id].cron, tcOffset, index);
@@ -148,7 +156,9 @@ define([
                         if (cLeft > leftBoundry && cLeft <= rightBoundry) {
                             return true;
                         }
+                        return false;
                     }
+                    isVerticallyInBounds = false;
                     return false;
                 }
             };

--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -131,7 +131,6 @@ define([
                     isVerticallyInBounds = false;
                     return false;
                 }
-                animationRef = raf(refresh);
             };
 
             config.data.subscribe(function() {
@@ -148,7 +147,7 @@ define([
                     clearTimeout(windowTimer);
                 }
                 windowTimer = setTimeout(function() {
-                    raf(refresh); 
+                    animationRef = raf(refresh); 
                 }, 2000);
             });
 
@@ -158,7 +157,7 @@ define([
                     clearTimeout(panelTimer);
                 }
                 panelTimer = setTimeout(function() {
-                    raf(refresh); 
+                    animationRef = raf(refresh); 
                 }, 2000);
  
             });

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -15,7 +15,7 @@ define([
     return Collection.extend({
         defaults: {
             timeframeFormat: 'MM/DD HH:mm',
-        	dateFormat: 'HH:mm',
+        	dateFormat: 'MM/DD HH:mm',
             template: 'cronjobManager/timeline/timeline',
             detailsTmpl: 'cronjobManager/timeline/details',
             imports: {

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -253,7 +253,7 @@ define([
          * Shows loader.
          */
         showLoader: function () {
-            loader.get(this.name).show();
+            loader.get('timeline_container.timeline_panel').show();
         },
 
         /**
@@ -271,7 +271,6 @@ define([
                 || this.rows == undefined) {
                 return;
             }
-            resolver(this.hideLoader, this);
             this.total = this.rows[0].total;
             this.updateRange();
             this.updateTimelineWidth();
@@ -310,6 +309,7 @@ define([
          * Handles dragging functionality on the timeline window
          */
         afterTimelineRender: function () {
+            resolver(this.hideLoader, this);
             var clicked = false, 
                 scrollVertical = true,
                 scrollHorizontal = true,

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -87,7 +87,7 @@ define([
         getOffset: function (job, asInt) {
             var startTime = job.executed_at || job.scheduled_at;
             var firstHour = this.getFirstHour(false);
-            var offset = this.diff(startTime)(firstHour) / this.scale;
+            var offset = this.diff(startTime, firstHour) / this.scale;
             if (offset < 0) {
                 offset = 0;
             }
@@ -223,18 +223,11 @@ define([
             this.now = (moment().diff(this.getFirstHour(), 'seconds')) / this.scale;
         },
 
-        diff: function(startTime) {
+        diff: function(startTime, endTime) {
             var timezoneOffset = new Date().getTimezoneOffset() * 60;
-            // startTime is in unix timestamp originally, but is converted
-            // to local time upon Date instantiation
-            // Let's change it back to UTC time
             startTime = (new Date(startTime).getTime() / 1000) - timezoneOffset;
-            return function(endTime) {
-                endTime = (new Date(endTime).getTime() / 1000);
-                return (function() {
-                    return (startTime - endTime);
-                })();
-            }
+            endTime = (new Date(endTime).getTime() / 1000);
+            return (startTime - endTime);
         },
 
         /**

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -278,8 +278,10 @@ define([
 
         transformObject: function (obj) {
             var properties = [];
+            var index = 0;
             ko.utils.objectForEach(obj, function (key, value) {
-                properties.push({ key: key, value: value });
+                properties.push({ index: index, key: key, value: value });
+                index++;
             });
             // we don't need the range key, which is stored
             // in the first element

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -283,6 +283,10 @@ define([
         },
 
         reloader: function () {
+            // Unregister all virtual foreach events
+            // so we don't overlap materializations
+            $(window).off()
+            $('.timeline-container__panel').off()
             resolver(this.reloadHandler, this);
         },
 

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -8,7 +8,7 @@ define([
     'uiRegistry',
     'moment',
     'uiCollection',
-    '../lib/knockout/bindings/boostrapExt',
+    '../lib/knockout/bindings/bootstrapExt',
 ], function (_, $, ko, layout, loader, resolver, registry, moment, Collection) {
     'use strict';
 

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -26,7 +26,7 @@ define([
                 '${ $.provider }:reloaded': 'onDataReloaded'
             },
             range: {},
-            scale: 6,
+            scale: 8,
             minScale: 3,
             maxScale: 15,
             step: 1,
@@ -266,7 +266,7 @@ define([
             this.transformObject(this.rows);
 
             $('.timeline-container').animate({
-                scrollLeft: (this.now / 1.25)
+                scrollLeft: (this.now - ($('.timeline-container').width() / 3))
             }, 500);
         },
 

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -8,6 +8,7 @@ define([
     'uiRegistry',
     'moment',
     'uiCollection',
+    '../lib/knockout/bindings/boostrapExt',
 ], function (_, $, ko, layout, loader, resolver, registry, moment, Collection) {
     'use strict';
 

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -32,12 +32,14 @@ define([
             step: 1,
             width: 0,
             now: 0,
+            total: 0,
             transformedRows: [],
             tracks: {
                 rows: true,
                 range: true,
                 width: true,
                 now: true,
+                total: true,
                 scale: true
             }
         },
@@ -260,6 +262,7 @@ define([
                 return;
             }
             resolver(this.hideLoader, this);
+            this.total = this.rows[0].total;
             this.updateRange();
             this.updateTimelineWidth();
             this.setNow();

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -26,10 +26,10 @@ define([
                 '${ $.provider }:reloaded': 'onDataReloaded'
             },
             range: {},
-            scale: 12.5,
-            minScale: 7,
+            scale: 6,
+            minScale: 3,
             maxScale: 15,
-            step: 2,
+            step: 1,
             width: 0,
             now: 0,
             transformedRows: [],
@@ -264,6 +264,10 @@ define([
             this.updateTimelineWidth();
             this.setNow();
             this.transformObject(this.rows);
+
+            $('.timeline-container').animate({
+                scrollLeft: (this.now / 1.25)
+            }, 500);
         },
 
         reloader: function () {

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -79,15 +79,20 @@ define([
          * the timeline
          *
          * @param {Object} job - cron record
+         * @param {boolean} asInt
          * @return {String}
          */
-        getOffset: function (job) {
+        getOffset: function (job, asInt) {
             var startTime = job.executed_at || job.scheduled_at,
                 offset = (moment.utc(startTime).local()
                     .diff(this.getFirstHour(), 'seconds')) 
                     / this.scale;
             if (offset < 0) {
                 offset = 0;
+            }
+
+            if (asInt == true) {
+                return offset;
             }
             return offset + 'px';
         },

--- a/view/adminhtml/web/templates/timeline/timeline.html
+++ b/view/adminhtml/web/templates/timeline/timeline.html
@@ -47,7 +47,7 @@
                     <fastForEach args="data: transformedRows">
                         <div class="row">
                             <div data-bind="attr: { class: 'cjm-timeline cjm-timeline_' + $data.key }">
-                                <fastForEach args="data: $data.value">
+                                <virtualForEach args="data: $data.value">
                                     <div>
                                         <div data-bind="
                                         attr: { 

--- a/view/adminhtml/web/templates/timeline/timeline.html
+++ b/view/adminhtml/web/templates/timeline/timeline.html
@@ -57,7 +57,7 @@
                                             },
                                             style: {
                                                 width: $parentContext.$parent.getCronWidth($data) + 'px',
-                                                left: $parentContext.$parent.getOffset($data)
+                                                transform: 'translateX(' + $parentContext.$parent.getOffset($data) + ')'
                                             }"/>
                                         <div tooltip=" trigger: '[data-tooltip-trigger=update-' + schedule_id + ']',
                                             action: 'hover',

--- a/view/adminhtml/web/templates/timeline/timeline.html
+++ b/view/adminhtml/web/templates/timeline/timeline.html
@@ -50,15 +50,15 @@
                                 <virtualForEach args="data: $data.value">
                                     <div>
                                         <div data-bind="
-                                        attr: { 
-                                            class: 'cron-job ' + $data.status,
-                                            id: $data.schedule_id,
-                                            'data-tooltip-trigger': 'update-' + $data.schedule_id,
-                                        },
-                                        style: {
-                                            width: $parentContext.$parent.getCronWidth($data) + 'px',
-                                            left: $parentContext.$parent.getOffset($data)
-                                        }"/>
+                                            attr: { 
+                                                class: 'cron-job ' + $data.status,
+                                                id: $data.schedule_id,
+                                                'data-tooltip-trigger': 'update-' + $data.schedule_id,
+                                            },
+                                            style: {
+                                                width: $parentContext.$parent.getCronWidth($data) + 'px',
+                                                left: $parentContext.$parent.getOffset($data)
+                                            }"/>
                                         <div tooltip=" trigger: '[data-tooltip-trigger=update-' + schedule_id + ']',
                                             action: 'hover',
                                             delay: 0,

--- a/view/adminhtml/web/templates/timeline/timeline.html
+++ b/view/adminhtml/web/templates/timeline/timeline.html
@@ -13,6 +13,12 @@
         </div>
     </div>
     <div class="wrapper">
+       <div data-role="spinner" data-component="timeline_container.timeline_panel" 
+           class="admin__data-grid-loading-mask">
+            <div class="spinner">
+                <span/><span/><span/><span/><span/><span/><span/><span/>
+            </div>
+       </div>
        <div class="left-content">
             <div class="timeline-unit row hours">
                 <div class="timeframe timeline-date">
@@ -112,7 +118,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                </fastForEach>
+                                </virtualForEach>
                             </div>
                         </div>
                     </fastForEach>

--- a/view/adminhtml/web/templates/timeline/timeline.html
+++ b/view/adminhtml/web/templates/timeline/timeline.html
@@ -1,4 +1,5 @@
 <div class="cronjobmanager" >
+    <span>Total Records: <text args="total" /></span>
     <div class="timeline-scale">
         <div class="data-slider"
             range="


### PR DESCRIPTION
# Timeline Performance Boost: Round 2

We can now load up-to 35,000 (more on this number below) cron jobs in the timeline, and do so with little to no lag/layout thrashing.

Page load time has decreased significantly (especially when loading large amounts of data), and NO browser cashes! :fireworks: 

(really) fixes issue #53 and works around issue #50 

The magic behind this is the new virtualization implementation: _VirtualForEach_ :fire: 

## VirtualForEach

Like the name suggests, the premise behind this node is to "virtualize" elements (cron job tasks) on the timeline. In other words, if a node can be viewed on the screen (meaning it's not hiding behind any element, or it's within the view port of the window) it will load it into the DOM. Oppositely, if an element is NOT visible, it won't load it into the DOM; thus making this implementation much more memory efficient. VirtualForEach knows exactly where a cron task will be on the timeline by "preCalculating" it's X and Y offsets before it's loaded on the DOM.

We're basically "lazy loading" elements to the DOM, so we don't get caught up with painting/layout calculations that would slow us down.

As the user browses around the timeline, VirtualForEach will keep track of all elements on the timeline; asynchronously, "materializing" and "de-materializing" cron job tasks as needed.

### What Exactly Is It?

VirtualForEach is a knockoutJs custom binding that is used by the Cron Job Manager's Timeline that allows us to load unlimited amounts of data into it, without any problems.

This will replace the fastForEach custom binding, by injecting a new "node" to be rendered by Magento's custom rendering engine.

In it's current state, it's not reusable, but maybe in the future it can be. 

## Why Exactly 35,000 Crons?

This number was picked because it's before the number where Magento's uiComponents cannot handle any more data coming in from the server. See the below comment pertaining to this bug: https://github.com/magento/magento2/issues/8084#issuecomment-306568076

Just for fun, I patched up the bug using the "LIBXML_PARSEHUGE" fix, and was able to load over 200k crons on the table very quickly.

Hopefully Magento will fix this bug...

## Other Notable Updates

* Improved loader UX

* "Total records loaded" noted on top of the timeline

## Demo

![timelinevfe](https://user-images.githubusercontent.com/6549623/42424034-858a185c-82d2-11e8-89de-7b8ab1e007dd.gif)
