### PR TITLE
Rest API Support

### DIFF
--- a/Api/Data/ScheduleInterface.php
+++ b/Api/Data/ScheduleInterface.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Api\Data;
+
+interface ScheduleInterface
+{
+    /**
+     * @return int
+     */
+    public function getScheduleId(): int;
+
+    /**
+     * @return string
+     */
+    public function getJobCode(): string;
+
+    /**
+     * @return string
+     */
+    public function getStatus(): string;
+
+    /**
+     * @return int|null
+     */
+    public function getPid();
+
+    /**
+     * @return string|null
+     */
+    public function getMessages();
+
+    /**
+     * @return string|null
+     */
+    public function getCreatedAt();
+
+    /**
+     * @return string|null
+     */
+    public function getScheduledAt();
+
+    /**
+     * @return string|null
+     */
+    public function getExecutedAt();
+
+    /**
+     * @return string|null
+     */
+    public function getFinishedAt();
+
+    /**
+     * @param int $scheduleId
+     * @return ScheduleInterface
+     */
+    public function setScheduleId(int $scheduleId): self;
+
+    /**
+     * @param string $jobCode
+     * @return ScheduleInterface
+     */
+    public function setJobCode(string $jobCode): self;
+
+    /**
+     * @param string $status
+     * @return ScheduleInterface
+     */
+    public function setStatus(string $status): self;
+
+    /**
+     * @param int $pid
+     * @return ScheduleInterface
+     */
+    public function setPid(int $pid): self;
+
+    /**
+     * @param string $messages
+     * @return ScheduleInterface
+     */
+    public function setMessages(string $messages): self;
+
+    /**
+     * @param string $createdAt
+     * @return ScheduleInterface
+     */
+    public function setCreatedAt(string $createdAt): self;
+
+    /**
+     * @param string $scheduledAt
+     * @return ScheduleInterface
+     */
+    public function setScheduledAt(string $scheduledAt): self;
+
+    /**
+     * @param string $executedAt
+     * @return ScheduleInterface
+     */
+    public function setExecutedAt(string $executedAt): self;
+
+    /**
+     * @param string $finishedAt
+     * @return ScheduleInterface
+     */
+    public function setFinishedAt(string $finishedAt): self;
+}

--- a/Api/Data/ScheduleSearchResultsInterface.php
+++ b/Api/Data/ScheduleSearchResultsInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Api\Data;
+
+use Magento\Framework\Api\SearchResultsInterface;
+
+interface ScheduleSearchResultsInterface extends SearchResultsInterface
+{
+    /**
+     * @return \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface[]
+     */
+    public function getItems();
+
+    /**
+     * @param \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface[]
+     * @return $this
+     */
+    public function setItems(array $items);
+}

--- a/Api/ScheduleManagementAdapterInterface.php
+++ b/Api/ScheduleManagementAdapterInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Api;
+
+/**
+ * Adapter used by REST API to work around the lack of data getters and setters in \Magento\Cron\Model\Schedule
+ * making the core cron model incompatible with param and result resolvers.
+ */
+interface ScheduleManagementAdapterInterface
+{
+    /**
+     * @param string $jobCode
+     * @return \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+     */
+    public function scheduleNow(string $jobCode): Data\ScheduleInterface;
+
+    /**
+     * @param string $jobCode
+     * @param int $time
+     * @return \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+     */
+    public function schedule(string $jobCode, int $time): Data\ScheduleInterface;
+}

--- a/Api/ScheduleManagementInterface.php
+++ b/Api/ScheduleManagementInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Api;
+
+use Magento\Cron\Model\Schedule;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+interface ScheduleManagementInterface
+{
+    const TIME_FORMAT = '%Y-%m-%d %H:%M:00';
+
+    /**
+     * @param int $scheduleId
+     * @return bool
+     * @throws NoSuchEntityException
+     * @throws CouldNotSaveException
+     */
+    public function execute(int $scheduleId): bool;
+
+    /**
+     * @return string[]
+     */
+    public function listJobs(): array;
+
+    /**
+     * @param string $jobCode
+     * @param string[]|null $groups
+     * @return string|null
+     */
+    public function getGroupId(string $jobCode, $groups = null);
+
+    /**
+     * @param string $jobCode
+     * @param int|null $time
+     * @return Schedule
+     */
+    public function createSchedule(string $jobCode, $time = null): Schedule;
+
+    /**
+     * @param string $jobCode
+     * @return Schedule
+     */
+    public function scheduleNow(string $jobCode): Schedule;
+
+    /**
+     * @param string $jobCode
+     * @param int $time
+     * @return Schedule
+     */
+    public function schedule(string $jobCode, int $time): Schedule;
+
+    /**
+     * @return bool
+     */
+    public function flush(): bool;
+}

--- a/Api/ScheduleRepositoryAdapterInterface.php
+++ b/Api/ScheduleRepositoryAdapterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Api;
+
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+/**
+ * Adapter used by REST API to work around the lack of data getters and setters in \Magento\Cron\Model\Schedule
+ * making the core cron model incompatible with param and result resolvers.
+ */
+interface ScheduleRepositoryAdapterInterface
+{
+    /**
+     * @param int $scheduleId
+     * @return \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+     * @throws NoSuchEntityException
+     */
+    public function get(int $scheduleId): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface;
+
+    /**
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+     * @return \EthanYehuda\CronjobManager\Api\Data\ScheduleSearchResultsInterface
+     */
+    public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria): \Magento\Framework\Api\SearchResultsInterface;
+
+    /**
+     * @param \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface $schedule
+     * @param int $scheduleId
+     * @return \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+     * @throws CouldNotSaveException
+     */
+    public function save(\EthanYehuda\CronjobManager\Api\Data\ScheduleInterface $schedule, $scheduleId = null): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface;
+}

--- a/Api/ScheduleRepositoryInterface.php
+++ b/Api/ScheduleRepositoryInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Api;
+
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+interface ScheduleRepositoryInterface
+{
+    /**
+     * @param int $scheduleId
+     * @return \Magento\Cron\Model\Schedule
+     * @throws NoSuchEntityException
+     */
+    public function get(int $scheduleId): \Magento\Cron\Model\Schedule;
+
+    /**
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+     * @return \Magento\Framework\Api\SearchResultsInterface
+     */
+    public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria): \Magento\Framework\Api\SearchResultsInterface;
+
+    /**
+     * @param \Magento\Cron\Model\Schedule $schedule
+     * @return \Magento\Cron\Model\Schedule
+     * @throws CouldNotSaveException
+     */
+    public function save(\Magento\Cron\Model\Schedule $schedule): \Magento\Cron\Model\Schedule;
+
+    /**
+     * @param \Magento\Cron\Model\Schedule $schedule
+     * @return bool True on success
+     * @throws CouldNotDeleteException
+     */
+    public function delete(\Magento\Cron\Model\Schedule $schedule): bool;
+
+    /**
+     * @param int $scheduleId
+     * @return bool True on success
+     * @throws CouldNotDeleteException
+     */
+    public function deleteById(int $scheduleId): bool;
+}

--- a/Model/Data/Schedule.php
+++ b/Model/Data/Schedule.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Model\Data;
+
+use Magento\Framework\DataObject;
+
+/**
+ * @codeCoverageIgnore
+ */
+class Schedule extends DataObject implements \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+{
+    const KEY_SCHEDULE_ID = 'schedule_id';
+    const KEY_JOB_CODE = 'job_code';
+    const KEY_STATUS = 'status';
+    const KEY_PID = 'pid';
+    const KEY_MESSAGES = 'messages';
+    const KEY_CREATED_AT = 'created_at';
+    const KEY_SCHEDULED_AT = 'scheduled_at';
+    const KEY_EXECUTED_AT = 'executed_at';
+    const KEY_FINISHED_AT = 'finished_at';
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+    }
+
+    public function getScheduleId(): int
+    {
+        return (int) $this->getData(self::KEY_SCHEDULE_ID);
+    }
+
+    public function getJobCode(): string
+    {
+        return $this->getData(self::KEY_JOB_CODE);
+    }
+
+    public function getStatus(): string
+    {
+        return $this->getData(self::KEY_STATUS);
+    }
+
+    public function getPid()
+    {
+        return (int) $this->getData(self::KEY_PID);
+    }
+
+    public function getMessages()
+    {
+        return $this->getData(self::KEY_MESSAGES);
+    }
+
+    public function getCreatedAt()
+    {
+        return $this->getData(self::KEY_CREATED_AT);
+    }
+
+    public function getScheduledAt()
+    {
+        return $this->getData(self::KEY_SCHEDULED_AT);
+    }
+
+    public function getExecutedAt()
+    {
+        return $this->getData(self::KEY_EXECUTED_AT);
+    }
+
+    public function getFinishedAt()
+    {
+        return $this->getData(self::KEY_FINISHED_AT);
+    }
+
+    public function setScheduleId(int $scheduleId): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        $this->setData(self::KEY_SCHEDULE_ID, $scheduleId);
+        return $this;
+    }
+
+    public function setJobCode(string $jobCode): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        $this->setData(self::KEY_JOB_CODE, $jobCode);
+        return $this;
+    }
+
+    public function setStatus(string $status): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        $this->setData(self::KEY_STATUS, $status);
+        return $this;
+    }
+
+    public function setPid(int $pid): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        $this->setData(self::KEY_PID, $pid);
+        return $this;
+    }
+
+    public function setMessages(string $messages): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        $this->setData(self::KEY_MESSAGES, $messages);
+        return $this;
+    }
+
+    public function setCreatedAt(string $createdAt): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        $this->setData(self::KEY_CREATED_AT, $createdAt);
+        return $this;
+    }
+
+    public function setScheduledAt(string $scheduledAt): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        $this->setData(self::KEY_SCHEDULED_AT, $scheduledAt);
+        return $this;
+    }
+
+    public function setExecutedAt(string $executedAt): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        $this->setData(self::KEY_EXECUTED_AT, $executedAt);
+        return $this;
+    }
+
+    public function setFinishedAt(string $finishedAt): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        $this->setData(self::KEY_FINISHED_AT, $finishedAt);
+        return $this;
+    }
+}

--- a/Model/ScheduleManagement.php
+++ b/Model/ScheduleManagement.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Model;
+
+use EthanYehuda\CronjobManager\Api\ScheduleManagementInterface;
+use EthanYehuda\CronjobManager\Helper\Processor;
+use EthanYehuda\CronjobManager\Api\ScheduleRepositoryInterface;
+use Magento\Cron\Model\ConfigInterface;
+use EthanYehuda\CronjobManager\Api\JobManagementInterface;
+use Magento\Cron\Model\ScheduleFactory;
+use Magento\Cron\Model\Schedule;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+
+class ScheduleManagement implements ScheduleManagementInterface
+{
+    /**
+     * @var Processor
+     */
+    private $processor;
+
+    /**
+     * @var ScheduleRepositoryInterface
+     */
+    private $scheduleRepository;
+
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
+     * @var DateTime
+     */
+    private $dateTime;
+
+    /**
+     * @var ScheduleFactory
+     */
+    private $scheduleFactory;
+
+    public function __construct(
+        Processor $processor,
+        ScheduleRepositoryInterface $scheduleRepository,
+        ConfigInterface $config,
+        DateTime $dateTime,
+        ScheduleFactory $scheduleFactory
+    ) {
+        $this->processor = $processor;
+        $this->scheduleRepository = $scheduleRepository;
+        $this->config = $config;
+        $this->dateTime = $dateTime;
+        $this->scheduleFactory = $scheduleFactory;
+    }
+
+    public function execute(int $scheduleId): bool
+    {
+        $groups = $this->listJobs();
+        $schedule = $this->scheduleRepository->get($scheduleId);
+        $jobCode = $schedule->getJobCode();
+        $groupId = $this->getGroupId($jobCode, $groups);
+        $jobConfig = $groups[$groupId][$jobCode];
+
+        $this->processor->runScheduledJob($jobConfig, $schedule);
+        $this->scheduleRepository->save($schedule);
+
+        return true;
+    }
+
+    public function listJobs(): array
+    {
+        return $this->config->getJobs();
+    }
+
+    public function createSchedule(string $jobCode, $time = null): Schedule
+    {
+        $time = strftime(ScheduleManagementInterface::TIME_FORMAT, $time ?? $this->dateTime->gmtTimestamp());
+
+        $schedule = $this->scheduleFactory->create()
+            ->setJobCode($jobCode)
+            ->setStatus(Schedule::STATUS_PENDING)
+            ->setCreatedAt(
+                strftime(ScheduleManagementInterface::TIME_FORMAT, $this->dateTime->gmtTimestamp())
+            )->setScheduledAt($time);
+
+        $this->scheduleRepository->save($schedule);
+
+        return $schedule;
+    }
+
+    public function scheduleNow(string $jobCode): Schedule
+    {
+        return $this->createSchedule($jobCode);
+    }
+
+    public function schedule(string $jobCode, int $time): Schedule
+    {
+        return $this->createSchedule($jobCode, $time);
+    }
+
+    public function getGroupId(string $jobCode, $groups = null): ?string
+    {
+        if (is_null($groups)) {
+            $groups = $this->listJobs();
+        }
+
+        foreach ($groups as $groupId => $crons) {
+            if (isset($crons[$jobCode])) {
+                return $groupId;
+            }
+        }
+
+        return null;
+    }
+
+    public function flush(): bool
+    {
+        $jobGroups = $this->listJobs();
+        foreach ($jobGroups as $groupId => $crons) {
+            $this->processor->cleanupJobs($groupId);
+        }
+
+        return true;
+    }
+}

--- a/Model/ScheduleManagementAdapter.php
+++ b/Model/ScheduleManagementAdapter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Model;
+
+use EthanYehuda\CronjobManager\Api\Data;
+use EthanYehuda\CronjobManager\Api\ScheduleManagementAdapterInterface;
+use EthanYehuda\CronjobManager\Api\Data\ScheduleInterfaceFactory;
+use EthanYehuda\CronjobManager\Api\ScheduleManagementInterface;
+
+class ScheduleManagementAdapter implements ScheduleManagementAdapterInterface
+{
+    /**
+     * @var ScheduleInterfaceFactory
+     */
+    private $scheduleFactory;
+
+    /**
+     * @var ScheduleManagementInterface
+     */
+    private $scheduleManagement;
+
+    public function __construct(
+        ScheduleInterfaceFactory $scheduleFactory,
+        ScheduleManagementInterface $scheduleManagement
+    ) {
+        $this->scheduleFactory = $scheduleFactory;
+        $this->scheduleManagement = $scheduleManagement;
+    }
+
+    public function scheduleNow(string $jobCode): Data\ScheduleInterface
+    {
+        $coreSchedule = $this->scheduleManagement->scheduleNow($jobCode);
+
+        return $this->scheduleFactory->create(['data' => $coreSchedule->getData()]);
+    }
+
+    public function schedule(string $jobCode, int $time): Data\ScheduleInterface
+    {
+        $coreSchedule = $this->scheduleManagement->schedule($jobCode, $time);
+
+        return $this->scheduleFactory->create(['data' => $coreSchedule->getData()]);
+    }
+}

--- a/Model/ScheduleRepository.php
+++ b/Model/ScheduleRepository.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Model;
+
+use EthanYehuda\CronjobManager\Api\ScheduleRepositoryInterface;
+use Magento\Cron\Model\Schedule;
+use Magento\Cron\Model\ScheduleFactory;
+use Magento\Cron\Model\ResourceModel\Schedule as ScheduleResource;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use EthanYehuda\CronjobManager\Model\ResourceModel\Schedule\CollectionFactory;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchResultsInterfaceFactory;
+use Magento\Framework\Api\SearchResultsInterface;
+
+class ScheduleRepository implements ScheduleRepositoryInterface
+{
+    /**
+     * @var ScheduleFactory
+     */
+    private $scheduleFactory;
+
+    /**
+     * @var ScheduleResource
+     */
+    private $scheduleResource;
+
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @var CollectionProcessorInterface
+     */
+    private $collectionProcessor;
+
+    /**
+     * @var SearchResultsInterfaceFactory
+     */
+    private $searchResultsFactory;
+
+    /**
+     * @var array
+     */
+    private $scheduleCache = [];
+
+    public function __construct(
+        ScheduleFactory $scheduleFactory,
+        ScheduleResource $scheduleResource,
+        CollectionFactory $collectionFactory,
+        CollectionProcessorInterface $collectionProcessor,
+        SearchResultsInterfaceFactory $searchResultsFactory
+    ) {
+        $this->scheduleFactory = $scheduleFactory;
+        $this->scheduleResource = $scheduleResource;
+        $this->collectionFactory = $collectionFactory;
+        $this->collectionProcessor = $collectionProcessor;
+        $this->searchResultsFactory = $searchResultsFactory;
+    }
+
+    public function get(int $scheduleId): Schedule
+    {
+        if (isset($this->scheduleCache[$scheduleId])) {
+            return $this->scheduleCache[$scheduleId];
+        }
+
+        $schedule = $this->scheduleFactory->create();
+        $this->scheduleResource->load($schedule, $scheduleId);
+
+        if (!$schedule->getId()) {
+            throw new NoSuchEntityException(__('The Schedule with the "%1" ID doesn\'t exist.', $scheduleId));
+        }
+
+        $this->scheduleCache[$scheduleId] = $schedule;
+        return $this->scheduleCache[$scheduleId];
+    }
+
+    public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria): SearchResultsInterface
+    {
+        /** @var \EthanYehuda\CronjobManager\Model\ResourceModel\Schedule\Collection $collection */
+        $collection = $this->collectionFactory->create();
+
+        $this->collectionProcessor->process($searchCriteria, $collection);
+
+        /** @var SearchResultsInterface $searchResults */
+        $searchResults = $this->searchResultsFactory->create();
+        $searchResults->setSearchCriteria($searchCriteria);
+        $searchResults->setItems($collection->getItems());
+        $searchResults->setTotalCount($collection->getSize());
+        return $searchResults;
+    }
+
+    public function save(Schedule $schedule): Schedule
+    {
+        try {
+            $this->scheduleResource->save($schedule);
+        } catch (\Exception $exception) {
+            throw new CouldNotSaveException(__($exception->getMessage()));
+        }
+        unset($this->scheduleCache[$schedule->getId()]);
+
+        return $schedule;
+    }
+
+    public function delete(Schedule $schedule): bool
+    {
+        try {
+            $this->scheduleResource->delete($schedule);
+        } catch (\Exception $exception) {
+            throw new CouldNotDeleteException(__($exception->getMessage()));
+        }
+        unset($this->scheduleCache[$schedule->getId()]);
+
+        return true;
+    }
+
+    public function deleteById(int $scheduleId): bool
+    {
+        return $this->delete($this->get($scheduleId));
+    }
+}

--- a/Model/ScheduleRepositoryAdapter.php
+++ b/Model/ScheduleRepositoryAdapter.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Model;
+
+use EthanYehuda\CronjobManager\Api\ScheduleRepositoryAdapterInterface;
+use EthanYehuda\CronjobManager\Api\ScheduleRepositoryInterface;
+use EthanYehuda\CronjobManager\Api\Data\ScheduleInterfaceFactory;
+use Magento\Cron\Model\ScheduleFactory;
+
+class ScheduleRepositoryAdapter implements ScheduleRepositoryAdapterInterface
+{
+    /**
+     * @var ScheduleRepositoryInterface
+     */
+    private $scheduleRepository;
+
+    /**
+     * @var ScheduleInterfaceFactory
+     */
+    private $scheduleFactory;
+
+    /**
+     * @var ScheduleFactory
+     */
+    private $coreScheduleFactory;
+
+    public function __construct(
+        ScheduleRepositoryInterface $scheduleRepository,
+        ScheduleInterfaceFactory $scheduleFactory,
+        ScheduleFactory $coreScheduleFactory
+    ) {
+        $this->scheduleRepository = $scheduleRepository;
+        $this->scheduleFactory = $scheduleFactory;
+        $this->coreScheduleFactory = $coreScheduleFactory;
+    }
+
+    public function get(int $scheduleId): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        $entity = $this->scheduleRepository->get($scheduleId);
+
+        return $this->scheduleFactory->create(['data' => $entity->getData()]);
+    }
+
+    public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria): \Magento\Framework\Api\SearchResultsInterface
+    {
+        $list = [];
+        $result = $this->scheduleRepository->getList($searchCriteria);
+        foreach ($result->getItems() as $key => $item) {
+            $list[$key] = $this->scheduleFactory->create(['data' => $item->getData()]);
+        }
+
+        $result->setItems($list);
+
+        return $result;
+    }
+
+    public function save(\EthanYehuda\CronjobManager\Api\Data\ScheduleInterface $schedule, $scheduleId = null): \EthanYehuda\CronjobManager\Api\Data\ScheduleInterface
+    {
+        if ($scheduleId) {
+            $schedule->setScheduleId($scheduleId);
+        }
+
+        $coreSchedule = $this->coreScheduleFactory->create(['data' => $schedule->getData()]);
+        $coreSchedule->setHasDataChanges(true);
+        $this->scheduleRepository->save($coreSchedule);
+
+        return $this->scheduleFactory->create(['data' => $coreSchedule->getData()]);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="EthanYehuda\CronjobManager\Api\ScheduleManagementInterface" type="EthanYehuda\CronjobManager\Model\ScheduleManagement" />
+    <preference for="EthanYehuda\CronjobManager\Api\ScheduleManagementAdapterInterface" type="EthanYehuda\CronjobManager\Model\ScheduleManagementAdapter" />
+    <preference for="EthanYehuda\CronjobManager\Api\ScheduleRepositoryInterface" type="EthanYehuda\CronjobManager\Model\ScheduleRepository" />
+    <preference for="EthanYehuda\CronjobManager\Api\ScheduleRepositoryAdapterInterface" type="EthanYehuda\CronjobManager\Model\ScheduleRepositoryAdapter" />
+    <preference for="EthanYehuda\CronjobManager\Api\Data\ScheduleSearchResultsInterface" type="Magento\Framework\Api\SearchResults" />
+    <preference for="EthanYehuda\CronjobManager\Api\Data\ScheduleInterface" type="EthanYehuda\CronjobManager\Model\Data\Schedule" />
     <virtualType name="Magento\Cron\Model\ResourceModel\Schedule\Virtual\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
         <arguments>
             <argument name="mainTable" xsi:type="string">cron_schedule</argument>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <!-- Schedule Repository -->
+    <route url="/V1/cronmanager/schedules/:scheduleId" method="GET">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleRepositoryAdapterInterface" method="get"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+    <route url="/V1/cronmanager/schedules" method="GET">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleRepositoryAdapterInterface" method="getList"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+    <route url="/V1/cronmanager/schedules" method="POST">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleRepositoryAdapterInterface" method="save"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+    <route url="/V1/cronmanager/schedules/:scheduleId" method="PUT">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleRepositoryAdapterInterface" method="save"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+    <route url="/V1/cronmanager/schedules/:scheduleId" method="DELETE">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleRepositoryInterface" method="deleteById"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+
+    <!-- Schedule Management -->
+    <route url="/V1/cronmanager/schedules/:scheduleId/execute" method="PUT">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleManagementInterface" method="execute"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+    <route url="/V1/cronmanager/schedules/flush" method="DELETE">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleManagementInterface" method="flush"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+
+    <!-- Job Management -->
+    <route url="/V1/cronmanager/jobs" method="GET">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleManagementInterface" method="listJobs"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+    <route url="/V1/cronmanager/jobs/:jobCode/group" method="GET">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleManagementInterface" method="getGroupId"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+    <route url="/V1/cronmanager/jobs/:jobCode/scheduleNow" method="POST">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleManagementAdapterInterface" method="scheduleNow"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+    <route url="/V1/cronmanager/jobs/:jobCode/schedule/time/:time" method="POST">
+        <service class="EthanYehuda\CronjobManager\Api\ScheduleManagementAdapterInterface" method="schedule"/>
+        <resources>
+            <resource ref="EthanYehuda_CronjobManager::cronjobmanager"/>
+        </resources>
+    </route>
+</routes>


### PR DESCRIPTION
This PR creates a number of Rest API endpoints for viewing and managing crons. Creates repository and management interfaces that separate out most of the logic in current `Manager` class. `Manager` is reduced to a legacy adapter passing requests to the appropriate interface and should probably be deprecated and removed in a future release. 

Below are the relevant swagger docs output from `https://{{storeUrl}}/swagger` using a valid admin access token:

```yaml
swagger: '2.0'
info:
  version: 1.x
basePath: /rest/all
schemes:
  - https
tags:
  - name: ethanYehudaCronjobManagerScheduleRepositoryV1
    description: ''
  - name: ethanYehudaCronjobManagerScheduleRepositoryAdapterV1
    description: Adapter used by REST API to work around the lack of data getters and setters in \Magento\Cron\Model\Schedule making the core cron model incompatible with param and result resolvers.
  - name: ethanYehudaCronjobManagerScheduleManagementV1
    description: ''
  - name: ethanYehudaCronjobManagerScheduleManagementAdapterV1
    description: Adapter used by REST API to work around the lack of data getters and setters in \Magento\Cron\Model\Schedule making the core cron model incompatible with param and result resolvers.
paths:
  '/V1/cronmanager/schedules/{scheduleId}':
    delete:
      tags:
        - ethanYehudaCronjobManagerScheduleRepositoryV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleRepositoryV1DeleteByIdDelete
      parameters:
        - name: scheduleId
          in: path
          type: integer
          required: true
      responses:
        '200':
          description: 200 Success.
          schema:
            type: boolean
            description: True on success
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        '500':
          description: Internal Server error
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
    get:
      tags:
        - ethanYehudaCronjobManagerScheduleRepositoryAdapterV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleRepositoryAdapterV1GetGet
      parameters:
        - name: scheduleId
          in: path
          type: integer
          required: true
      responses:
        '200':
          description: 200 Success.
          schema:
            $ref: '#/definitions/ethan-yehuda-cronjob-manager-data-schedule-interface'
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        '500':
          description: Internal Server error
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
    put:
      tags:
        - ethanYehudaCronjobManagerScheduleRepositoryAdapterV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleRepositoryAdapterV1SavePut
      parameters:
        - name: scheduleId
          in: path
          type: integer
          required: true
        - name: ethanYehudaCronjobManagerScheduleRepositoryAdapterV1SavePutBody
          in: body
          schema:
            required:
              - schedule
            properties:
              schedule:
                $ref: '#/definitions/ethan-yehuda-cronjob-manager-data-schedule-interface'
            type: object
      responses:
        '200':
          description: 200 Success.
          schema:
            $ref: '#/definitions/ethan-yehuda-cronjob-manager-data-schedule-interface'
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        '500':
          description: Internal Server error
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
  /V1/cronmanager/schedules:
    get:
      tags:
        - ethanYehudaCronjobManagerScheduleRepositoryAdapterV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleRepositoryAdapterV1GetListGet
      parameters:
        - name: 'searchCriteria[filterGroups][0][filters][0][field]'
          in: query
          type: string
          description: Field
        - name: 'searchCriteria[filterGroups][0][filters][0][value]'
          in: query
          type: string
          description: Value
        - name: 'searchCriteria[filterGroups][0][filters][0][conditionType]'
          in: query
          type: string
          description: Condition type
        - name: 'searchCriteria[sortOrders][0][field]'
          in: query
          type: string
          description: Sorting field.
        - name: 'searchCriteria[sortOrders][0][direction]'
          in: query
          type: string
          description: Sorting direction.
        - name: 'searchCriteria[pageSize]'
          in: query
          type: integer
          description: Page size.
        - name: 'searchCriteria[currentPage]'
          in: query
          type: integer
          description: Current page.
      responses:
        '200':
          description: 200 Success.
          schema:
            $ref: '#/definitions/ethan-yehuda-cronjob-manager-data-schedule-search-results-interface'
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
    post:
      tags:
        - ethanYehudaCronjobManagerScheduleRepositoryAdapterV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleRepositoryAdapterV1SavePost
      parameters:
        - name: ethanYehudaCronjobManagerScheduleRepositoryAdapterV1SavePostBody
          in: body
          schema:
            required:
              - schedule
            properties:
              schedule:
                $ref: '#/definitions/ethan-yehuda-cronjob-manager-data-schedule-interface'
              scheduleId:
                type: integer
            type: object
      responses:
        '200':
          description: 200 Success.
          schema:
            $ref: '#/definitions/ethan-yehuda-cronjob-manager-data-schedule-interface'
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        '500':
          description: Internal Server error
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
  '/V1/cronmanager/schedules/{scheduleId}/execute':
    put:
      tags:
        - ethanYehudaCronjobManagerScheduleManagementV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleManagementV1ExecutePut
      parameters:
        - name: scheduleId
          in: path
          type: integer
          required: true
      responses:
        '200':
          description: 200 Success.
          schema:
            type: boolean
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        '500':
          description: Internal Server error
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
  /V1/cronmanager/schedules/flush:
    delete:
      tags:
        - ethanYehudaCronjobManagerScheduleManagementV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleManagementV1FlushDelete
      responses:
        '200':
          description: 200 Success.
          schema:
            type: boolean
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
  /V1/cronmanager/jobs:
    get:
      tags:
        - ethanYehudaCronjobManagerScheduleManagementV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleManagementV1ListJobsGet
      responses:
        '200':
          description: 200 Success.
          schema:
            type: array
            items:
              type: string
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
  '/V1/cronmanager/jobs/{jobCode}/group':
    get:
      tags:
        - ethanYehudaCronjobManagerScheduleManagementV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleManagementV1GetGroupIdGet
      parameters:
        - name: jobCode
          in: path
          type: string
          required: true
        - name: groups
          in: query
          type: array
          items:
            type: string
          required: false
      responses:
        '200':
          description: 200 Success.
          schema:
            type: string
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
  '/V1/cronmanager/jobs/{jobCode}/scheduleNow':
    post:
      tags:
        - ethanYehudaCronjobManagerScheduleManagementAdapterV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleManagementAdapterV1ScheduleNowPost
      parameters:
        - name: jobCode
          in: path
          type: string
          required: true
      responses:
        '200':
          description: 200 Success.
          schema:
            $ref: '#/definitions/ethan-yehuda-cronjob-manager-data-schedule-interface'
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
  '/V1/cronmanager/jobs/{jobCode}/schedule/time/{time}':
    post:
      tags:
        - ethanYehudaCronjobManagerScheduleManagementAdapterV1
      description: ''
      operationId: ethanYehudaCronjobManagerScheduleManagementAdapterV1SchedulePost
      parameters:
        - name: jobCode
          in: path
          type: string
          required: true
        - name: time
          in: path
          type: integer
          required: true
      responses:
        '200':
          description: 200 Success.
          schema:
            $ref: '#/definitions/ethan-yehuda-cronjob-manager-data-schedule-interface'
        '401':
          description: 401 Unauthorized
          schema:
            $ref: '#/definitions/error-response'
        default:
          description: Unexpected error
          schema:
            $ref: '#/definitions/error-response'
definitions:
  error-response:
    type: object
    properties:
      message:
        type: string
        description: Error message
      errors:
        $ref: '#/definitions/error-errors'
      code:
        type: integer
        description: Error code
      parameters:
        $ref: '#/definitions/error-parameters'
      trace:
        type: string
        description: Stack trace
    required:
      - message
  error-errors:
    type: array
    description: Errors list
    items:
      $ref: '#/definitions/error-errors-item'
  error-errors-item:
    type: object
    description: Error details
    properties:
      message:
        type: string
        description: Error message
      parameters:
        $ref: '#/definitions/error-parameters'
  error-parameters:
    type: array
    description: Error parameters list
    items:
      $ref: '#/definitions/error-parameters-item'
  error-parameters-item:
    type: object
    description: Error parameters item
    properties:
      resources:
        type: string
        description: ACL resource
      fieldName:
        type: string
        description: Missing or invalid field name
      fieldValue:
        type: string
        description: Incorrect field value
  ethan-yehuda-cronjob-manager-data-schedule-interface:
    type: object
    description: ''
    properties:
      schedule_id:
        type: integer
      job_code:
        type: string
      status:
        type: string
      pid:
        type: integer
      messages:
        type: string
      created_at:
        type: string
      scheduled_at:
        type: string
      executed_at:
        type: string
      finished_at:
        type: string
    required:
      - schedule_id
      - job_code
      - status
  ethan-yehuda-cronjob-manager-data-schedule-search-results-interface:
    type: object
    description: ''
    properties:
      items:
        type: array
        items:
          $ref: '#/definitions/ethan-yehuda-cronjob-manager-data-schedule-interface'
      search_criteria:
        $ref: '#/definitions/framework-search-criteria-interface'
      total_count:
        type: integer
        description: Total count.
    required:
      - items
      - search_criteria
      - total_count
  framework-search-criteria-interface:
    type: object
    description: Search criteria interface.
    properties:
      filter_groups:
        type: array
        description: A list of filter groups.
        items:
          $ref: '#/definitions/framework-search-filter-group'
      sort_orders:
        type: array
        description: Sort order.
        items:
          $ref: '#/definitions/framework-sort-order'
      page_size:
        type: integer
        description: Page size.
      current_page:
        type: integer
        description: Current page.
    required:
      - filter_groups
  framework-search-filter-group:
    type: object
    description: Groups two or more filters together using a logical OR
    properties:
      filters:
        type: array
        description: A list of filters in this group
        items:
          $ref: '#/definitions/framework-filter'
  framework-filter:
    type: object
    description: Filter which can be used by any methods from service layer.
    properties:
      field:
        type: string
        description: Field
      value:
        type: string
        description: Value
      condition_type:
        type: string
        description: Condition type
    required:
      - field
      - value
  framework-sort-order:
    type: object
    description: Data object for sort order.
    properties:
      field:
        type: string
        description: Sorting field.
      direction:
        type: string
        description: Sorting direction.
    required:
      - field
      - direction
```

Fixes #83 