### PR TITLE
Fixes #91: Replicate native CLI handling to launch cron with correct store id

### DIFF
--- a/Console/Command/Runjob.php
+++ b/Console/Command/Runjob.php
@@ -50,7 +50,7 @@ class Runjob extends Command
         $objectManager = $this->objectManagerFactory->create($omParams);
 
         $jobCode = $input->getArgument(self::INPUT_KEY_JOB_CODE);
-        $cron = $objectManager->create(\EthanYehuda\CronjobManager\Model\Cron::class);
+        $cron = $objectManager->create(\EthanYehuda\CronjobManager\Model\Cron\Runner::class);
         list($resultCode, $resultMessage) = $cron->runCron($jobCode);
         $output->writeln($resultMessage);
         return $resultCode;

--- a/Console/Command/Runjob.php
+++ b/Console/Command/Runjob.php
@@ -2,43 +2,27 @@
 
 namespace EthanYehuda\CronjobManager\Console\Command;
 
-use EthanYehuda\CronjobManager\Model\ManagerFactory;
+use Magento\Framework\App\ObjectManagerFactory;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManager;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
-use Magento\Framework\App\Area;
-use Magento\Framework\App\State;
-use Magento\Framework\Console\Cli;
-use Magento\Framework\Stdlib\DateTime\DateTimeFactory;
 
 class Runjob extends Command
 {
     const INPUT_KEY_JOB_CODE = 'job_code';
 
     /**
-     * @var ManagerFactory $managerFactory
+     * @var ObjectManagerFactory
      */
-    private $managerFactory;
-
-    /**
-     * @var \Magento\Framework\App\State $state
-     */
-    private $state;
-
-    /**
-     * @var DateTimeFactory $dateTimeFactory
-     */
-    private $dateTimeFactory;
+    private $objectManagerFactory;
 
     public function __construct(
-        State $state,
-        ManagerFactory $managerFactory,
-        DateTimeFactory $dateTimeFactory
+        ObjectManagerFactory $objectManagerFactory
     ) {
-        $this->managerFactory = $managerFactory;
-        $this->state = $state;
-        $this->dateTimeFactory = $dateTimeFactory;
+        $this->objectManagerFactory = $objectManagerFactory;
         parent::__construct();
     }
 
@@ -60,27 +44,15 @@ class Runjob extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $manager = $this->managerFactory->create();
-        $dateTime = $this->dateTimeFactory->create();
+        $omParams = $_SERVER;
+        $omParams[StoreManager::PARAM_RUN_CODE] = Store::ADMIN_CODE;
+        $omParams[Store::CUSTOM_ENTRY_POINT_PARAM] = true;
+        $objectManager = $this->objectManagerFactory->create($omParams);
 
-        try {
-            $this->state->setAreaCode(Area::AREA_ADMINHTML);
-        } catch (\Magento\Framework\Exception\LocalizedException $exception) {
-            // Area code is already set
-        }
-
-        try {
-            // lets create a new cron job and dispatch it
-            $jobCode = $input->getArgument(self::INPUT_KEY_JOB_CODE);
-            $now = strftime('%Y-%m-%dT%H:%M:%S', $dateTime->gmtTimestamp());
-
-            $schedule = $manager->createCronJob($jobCode, $now);
-            $manager->dispatchCron(null, $jobCode, $schedule);
-            $output->writeln("$jobCode successfully ran");
-            return Cli::RETURN_SUCCESS;
-        } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $output->writeln($e->getMessage());
-            return Cli::RETURN_FAILURE;
-        }
+        $jobCode = $input->getArgument(self::INPUT_KEY_JOB_CODE);
+        $cron = $objectManager->create(\EthanYehuda\CronjobManager\Model\Cron::class);
+        list($resultCode, $resultMessage) = $cron->runCron($jobCode);
+        $output->writeln($resultMessage);
+        return $resultCode;
     }
 }

--- a/Console/Command/Runjob.php
+++ b/Console/Command/Runjob.php
@@ -44,6 +44,9 @@ class Runjob extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        /**
+         * @todo Find a way to avoid using `ObjectManager`
+         */
         $omParams = $_SERVER;
         $omParams[StoreManager::PARAM_RUN_CODE] = Store::ADMIN_CODE;
         $omParams[Store::CUSTOM_ENTRY_POINT_PARAM] = true;

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Model;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Magento\Framework\Console\Cli;
+use Magento\Framework\Stdlib\DateTime\DateTimeFactory;
+
+class Cron
+{
+    /**
+     * @var State
+     */
+    private $state;
+
+    /**
+     * @var ManagerFactory
+     */
+    private $managerFactory;
+
+    /**
+     * @var DateTimeFactory
+     */
+    private $dateTimeFactory;
+
+    public function __construct(
+        State $state,
+        ManagerFactory $managerFactory,
+        DateTimeFactory $dateTimeFactory
+    ) {
+        $this->state = $state;
+        $this->managerFactory = $managerFactory;
+        $this->dateTimeFactory = $dateTimeFactory;
+    }
+
+    public function runCron($jobCode)
+    {
+        $this->state->setAreaCode(Area::AREA_CRONTAB);
+
+        $manager = $this->managerFactory->create();
+        $dateTime = $this->dateTimeFactory->create();
+
+        try {
+            // lets create a new cron job and dispatch it
+            $now = strftime('%Y-%m-%dT%H:%M:%S', $dateTime->gmtTimestamp());
+
+            $schedule = $manager->createCronJob($jobCode, $now);
+            $manager->dispatchCron(null, $jobCode, $schedule);
+            return [Cli::RETURN_SUCCESS, "$jobCode successfully ran"];
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            return [Cli::RETURN_FAILURE, $e->getMessage()];
+        }
+    }
+}

--- a/Model/Cron/Runner.php
+++ b/Model/Cron/Runner.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace EthanYehuda\CronjobManager\Model;
+namespace EthanYehuda\CronjobManager\Model\Cron;
 
 use EthanYehuda\CronjobManager\Api\ScheduleManagementInterfaceFactory;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
 
-class Cron
+class Runner
 {
     /**
      * @var State


### PR DESCRIPTION
Explanation of this PR has been done in issue #91.

This is almost a straight implementation of Magento Core Cron command, with two details:
* `$omParams[StoreManager::PARAM_RUN_CODE]` has been set to `Store::ADMIN_CODE` (whereas core is set to `'admin'` literal string)
* `try…catch` around `setAreaCode()` has been removed, as it should not occur anymore with the new `ObjectManager` instance.