### PR TITLE
[FEATURE] Add color for status column on Cron Job Dashboard

### DIFF
--- a/Ui/Component/Listing/Column/ScheduleStatus.php
+++ b/Ui/Component/Listing/Column/ScheduleStatus.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Ui\Component\Listing\Column;
+
+use Magento\Ui\Component\Listing\Columns\Column;
+use EthanYehuda\CronjobManager\Api\Data\ScheduleInterface;
+
+class ScheduleStatus extends Column
+{
+    /**
+     * Prepare Data Source
+     *
+     * @param array $dataSource
+     * @return array
+     */
+    public function prepareDataSource(array $dataSource)
+    {
+        if (isset($dataSource['data']['items'])) {
+            foreach ($dataSource['data']['items'] as &$item) {
+                switch ($item[$this->getData('name')]) {
+                    case ScheduleInterface::STATUS_ERROR:
+                        $class = 'grid-severity-critical';
+                        $text = __('Error');
+                        break;
+                    case ScheduleInterface::STATUS_MISSED:
+                        $class = 'grid-severity-minor';
+                        $text = __('Missed');
+                        break;
+                    case ScheduleInterface::STATUS_PENDING:
+                        $class = 'grid-severity-pending';
+                        $text = __('Pending');
+                        break;
+                    case ScheduleInterface::STATUS_RUNNING:
+                        $class = 'grid-severity-running';
+                        $text = __('Running');
+                        break;
+                    case ScheduleInterface::STATUS_SUCCESS:
+                        $class = 'grid-severity-notice';
+                        $text = __('Success');
+                        break;
+                    case ScheduleInterface::STATUS_KILLED:
+                        $class = 'grid-severity-critical';
+                        $text = __('Killed');
+                        break;
+                    default:
+                        $class = 'grid-severity-minor';
+                        $text = __('Unknown');
+                        break;
+                }
+
+                $html = '<span class="' . $class . '"><span>' . $text . '</span></span>';
+                $item[$this->getData('name')] = $html;
+            }
+        }
+
+        return $dataSource;
+    }
+}

--- a/view/adminhtml/ui_component/cronjobmanager_manage_grid.xml
+++ b/view/adminhtml/ui_component/cronjobmanager_manage_grid.xml
@@ -154,13 +154,13 @@
 				</item>
 			</argument>
 		</column>
-		<column name="status">
+		<column name="status" class="EthanYehuda\CronjobManager\Ui\Component\Listing\Column\ScheduleStatus">
 			<argument name="data" xsi:type="array">
 				<item name="options" xsi:type="object">EthanYehuda\CronjobManager\Model\Schedule\Source\Status</item>
 				<item name="config" xsi:type="array">
 					<item name="filter" xsi:type="string">select</item>
 					<item name="sorting" xsi:type="string">asc</item>
-					<item name="component" xsi:type="string">Magento_Ui/js/grid/columns/select</item>
+					<item name="component" xsi:type="string">EthanYehuda_CronjobManager/js/grid/columns/html</item>
 					<item name="dataType" xsi:type="string">select</item>
 					<item name="label" xsi:type="string" translate="true">Status</item>
 					<item name="draggable" xsi:type="boolean">false</item>

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -1,2 +1,3 @@
 @import 'module/_visualizer.less';
 @import 'module/_timeline.less';
+@import 'module/_grid.less';

--- a/view/adminhtml/web/css/source/module/_grid.less
+++ b/view/adminhtml/web/css/source/module/_grid.less
@@ -1,0 +1,35 @@
+//
+//    Grid - status and severity
+// --------------------------------------
+
+@grid-severity-running-color: #808080;
+@grid-severity-running-background-color: #ffff00;
+@grid-severity-running-border: #d8d8d8;
+
+@grid-severity-pending-color: #808080;
+@grid-severity-pending-background-color: #cccccc;
+@grid-severity-pending-border: #d8d8d8;
+
+
+.grid-severity-running,
+.grid-severity-pending {
+  display: block;
+  border: 1px solid @grid-severity-pending-border;
+  padding: 0 3px;
+  font-weight: bold;
+  line-height: 17px;
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.grid-severity-running {
+  border-color: @grid-severity-running-border;
+  background: @grid-severity-running-background-color;
+  color: @grid-severity-running-color;
+}
+
+.grid-severity-pending {
+  border-color: @grid-severity-pending-border;
+  background: @grid-severity-pending-background-color;
+  color: @grid-severity-pending-color;
+}

--- a/view/adminhtml/web/js/grid/columns/html.js
+++ b/view/adminhtml/web/js/grid/columns/html.js
@@ -1,0 +1,339 @@
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define([
+    'underscore',
+    'uiRegistry',
+    'mageUtils',
+    'uiElement'
+], function (_, registry, utils, Element) {
+    'use strict';
+
+    return Element.extend({
+        defaults: {
+            headerTmpl: 'ui/grid/columns/text',
+            bodyTmpl: 'ui/grid/cells/html',
+            disableAction: false,
+            controlVisibility: true,
+            sortable: true,
+            sorting: false,
+            visible: true,
+            draggable: true,
+            fieldClass: {},
+            ignoreTmpls: {
+                fieldAction: true
+            },
+            statefull: {
+                visible: true,
+                sorting: true
+            },
+            imports: {
+                exportSorting: 'sorting'
+            },
+            listens: {
+                '${ $.provider }:params.sorting.field': 'onSortChange'
+            },
+            modules: {
+                source: '${ $.provider }'
+            }
+        },
+
+        /**
+         * Initializes column component.
+         *
+         * @returns {Column} Chainable.
+         */
+        initialize: function () {
+            this._super()
+                .initFieldClass();
+
+            return this;
+        },
+
+        /**
+         * Initializes observable properties.
+         *
+         * @returns {Column} Chainable.
+         */
+        initObservable: function () {
+            this._super()
+                .track([
+                    'visible',
+                    'sorting',
+                    'disableAction'
+                ])
+                .observe([
+                    'dragging'
+                ]);
+
+            return this;
+        },
+
+        /**
+         * Extends list of field classes.
+         *
+         * @returns {Column} Chainable.
+         */
+        initFieldClass: function () {
+            _.extend(this.fieldClass, {
+                _dragging: this.dragging
+            });
+
+            return this;
+        },
+
+        /**
+         * Applies specified stored state of a column or one of its' properties.
+         *
+         * @param {String} state - Defines what state should be used: saved or default.
+         * @param {String} [property] - Defines what columns' property should be applied.
+         *      If not specified, then all columns stored properties will be used.
+         * @returns {Column} Chainable.
+         */
+        applyState: function (state, property) {
+            var namespace = this.storageConfig.root;
+
+            if (property) {
+                namespace += '.' + property;
+            }
+
+            this.storage('applyStateOf', state, namespace);
+
+            return this;
+        },
+
+        /**
+         * Sets columns' sorting. If column is currently sorted,
+         * than its' direction will be toggled.
+         *
+         * @param {*} [enable=true] - If false, than sorting will
+         *      be removed from a column.
+         * @returns {Column} Chainable.
+         */
+        sort: function (enable) {
+            if (!this.sortable) {
+                return this;
+            }
+
+            enable !== false ?
+                this.toggleSorting() :
+                this.sorting = false;
+
+            return this;
+        },
+
+        /**
+         * Sets descending columns' sorting.
+         *
+         * @returns {Column} Chainable.
+         */
+        sortDescending: function () {
+            if (this.sortable) {
+                this.sorting = 'desc';
+            }
+
+            return this;
+        },
+
+        /**
+         * Sets ascending columns' sorting.
+         *
+         * @returns {Column} Chainable.
+         */
+        sortAscending: function () {
+            if (this.sortable) {
+                this.sorting = 'asc';
+            }
+
+            return this;
+        },
+
+        /**
+         * Toggles sorting direction.
+         *
+         * @returns {Column} Chainable.
+         */
+        toggleSorting: function () {
+            this.sorting === 'asc' ?
+                this.sortDescending() :
+                this.sortAscending();
+
+            return this;
+        },
+
+        /**
+         * Checks if column is sorted.
+         *
+         * @returns {Boolean}
+         */
+        isSorted: function () {
+            return !!this.sorting;
+        },
+
+        /**
+         * Exports sorting data to the dataProvider if
+         * sorting of a column is enabled.
+         */
+        exportSorting: function () {
+            if (!this.sorting) {
+                return;
+            }
+
+            this.source('set', 'params.sorting', {
+                field: this.index,
+                direction: this.sorting
+            });
+        },
+
+        /**
+         * Checks if column has an assigned action that will
+         * be performed when clicking on one of its' fields.
+         *
+         * @returns {Boolean}
+         */
+        hasFieldAction: function () {
+            return !!this.fieldAction || !!this.fieldActions;
+        },
+
+        /**
+         * Applies action described in a 'fieldAction' property
+         * or actions described in 'fieldActions' property.
+         *
+         * @param {Number} rowIndex - Index of a row which initiates action.
+         * @returns {Column} Chainable.
+         *
+         * @example Example of fieldAction definition, which is equivalent to
+         *      referencing to external component named 'listing.multiselect'
+         *      and calling its' method 'toggleSelect' with params [rowIndex, true] =>
+         *
+         *      {
+         *          provider: 'listing.multiselect',
+         *          target: 'toggleSelect',
+         *          params: ['${ $.$data.rowIndex }', true]
+         *      }
+         */
+        applyFieldAction: function (rowIndex) {
+            if (!this.hasFieldAction() || this.disableAction) {
+                return this;
+            }
+
+            if (this.fieldActions) {
+                this.fieldActions.forEach(this.applySingleAction.bind(this, rowIndex), this);
+            } else {
+                this.applySingleAction(rowIndex);
+            }
+
+            return this;
+        },
+
+        /**
+         * Applies single action
+         *
+         * @param {Number} rowIndex - Index of a row which initiates action.
+         * @param {Object} action - Action (fieldAction) to be applied
+         *
+         */
+        applySingleAction: function (rowIndex, action) {
+            var callback;
+
+            action = action || this.fieldAction;
+            action = utils.template(action, {
+                column: this,
+                rowIndex: rowIndex
+            }, true);
+
+            callback = this._getFieldCallback(action);
+
+            if (_.isFunction(callback)) {
+                callback();
+            }
+        },
+
+        /**
+         * Returns field action handler if it was specified.
+         *
+         * @param {Object} record - Record object with which action is associated.
+         * @returns {Function|Undefined}
+         */
+        getFieldHandler: function (record) {
+            if (this.hasFieldAction()) {
+                return this.applyFieldAction.bind(this, record._rowIndex);
+            }
+        },
+
+        /**
+         * Creates action callback based on its' data.
+         *
+         * @param {Object} action - Actions' object.
+         * @returns {Function|Boolean} Callback function or false
+         *      value if it was impossible create a callback.
+         */
+        _getFieldCallback: function (action) {
+            var args     = action.params || [],
+                callback = action.target;
+
+            if (action.provider && action.target) {
+                args.unshift(action.target);
+
+                callback = registry.async(action.provider);
+            }
+
+            if (!_.isFunction(callback)) {
+                return false;
+            }
+
+            return function () {
+                callback.apply(callback, args);
+            };
+        },
+
+        /**
+         * Ment to preprocess data associated with a current columns' field.
+         *
+         * @param {Object} record - Data to be preprocessed.
+         * @returns {String}
+         */
+        getLabel: function (record) {
+            return record[this.index];
+        },
+
+        /**
+         * Returns list of classes that should be applied to a field.
+         *
+         * @returns {Object}
+         */
+        getFieldClass: function () {
+            return this.fieldClass;
+        },
+
+        /**
+         * Returns path to the columns' header template.
+         *
+         * @returns {String}
+         */
+        getHeader: function () {
+            return this.headerTmpl;
+        },
+
+        /**
+         * Returns path to the columns' body template.
+         *
+         * @returns {String}
+         */
+        getBody: function () {
+            return this.bodyTmpl;
+        },
+
+        /**
+         * Listener of the providers' sorting state changes.
+         *
+         * @param {Srting} field - Field by which current sorting is performed.
+         */
+        onSortChange: function (field) {
+            if (field !== this.index) {
+                this.sort(false);
+            }
+        }
+    });
+});


### PR DESCRIPTION
### Description
Colorize status columns from Cronjob Dashboard

### Fixed Issues (if relevant)

**[Ethan3600/magento2-CronjobManager#107](https://github.com/Ethan3600/magento2-CronjobManager/issues/107): Colorize status columns**

Colorize the status column:

- Pending: gray
- Running: yellow
- Success: green
- Missed: orange
- Error: red
- Killed: red
