### PR TITLE
Tagging PHP version to 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ethanyehuda/magento2-cronjobmanager",
     "description": "A module for managing scheduled cron jobs from magento's admin panel",
     "require": {
-        "php": "~7.1.0||~7.2.0",
+        "php": "~7.1.0||~7.2.0||~7.3.0",
         "magento/framework": "~100.3.0-dev|~101.0.0|~102.0.0"
     },
     "type": "magento2-module",


### PR DESCRIPTION
This PR resolves #130 - there are no compatibility issues with using PHP 7.3 with the latest version of **1.x-develop**:
```
magento2-CronjobManager amellen$ phpco -p --colors --extensions=php,phtml --runtime-set testVersion 7.3 .
............................................................ 60 / 87 (69%)
...........................                                  87 / 87 (100%)


Time: 1.24 secs; Memory: 10MB
```

I used [fortrabbit/phpco-docker](https://github.com/fortrabbit/phpco-docker) to test this.