### PR TITLE
Fix testsuite and add coveralls.io integration

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,5 @@
 # for php-coveralls
-coverage_clover: magento2/dev/tests/unit/clover.xml
-json_path: magento2/dev/tests/unit/coveralls-upload.json
+coverage_clover:
+  - magento2/dev/tests/integration/tmp/clover.xml
+  - magento2/dev/tests/unit/tmp/clover.xml
+json_path: magento2/dev/tests/unit/tmp/coveralls-upload.json

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,3 @@
+# for php-coveralls
+coverage_clover: magento2/dev/tests/unit/clover.xml
+json_path: magento2/dev/tests/unit/coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
       env:
        - MAGENTO_VERSION=2.4-develop
        - TEST_SUITE=unit
+       - TEST_COVERAGE=true
     - php: 7.3
       env:
        - MAGENTO_VERSION=2.3
@@ -71,3 +72,5 @@ cache:
     - $HOME/.composer/cache
 before_script: ./.travis/before_script.sh
 script: phpunit -c magento2/dev/tests/$TEST_SUITE
+after_success:
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry php magento2/vendor/php-coveralls/php-coveralls/bin/php-coveralls -v ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,4 +77,4 @@ before_script: ./.travis/before_script.sh
 script:
     - if [[ $TEST_SUITE == 'coverage' ]]; then phpunit -c magento2/dev/tests/unit && phpunit -c magento2/dev/tests/integration ; else phpunit -c magento2/dev/tests/$TEST_SUITE ; fi
 after_success:
-  - if [[ $TEST_SUITE == 'coverage' ]]; then travis_retry php magento2/vendor/php-coveralls/php-coveralls/bin/php-coveralls -v ; fi
+  - if [[ $TEST_SUITE == 'coverage' ]]; then travis_retry php $COMPOSER_BIN_DIR/php-coveralls -v ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,14 @@ matrix:
       env:
        - MAGENTO_VERSION=2.3
        - TEST_SUITE=unit
+    - php: 7.2
+      env:
+        - MAGENTO_VERSION=2.2
+        - TEST_SUITE=integration
+    - php: 7.2
+      env:
+        - MAGENTO_VERSION=2.2
+        - TEST_SUITE=unit
     - php: 7.1
       env:
         - MAGENTO_VERSION=2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,14 +47,6 @@ matrix:
        - TEST_SUITE=unit
     - php: 7.1
       env:
-       - MAGENTO_VERSION=2.3
-       - TEST_SUITE=integration
-    - php: 7.1
-      env:
-       - MAGENTO_VERSION=2.3
-       - TEST_SUITE=unit
-    - php: 7.1
-      env:
         - MAGENTO_VERSION=2.2
         - TEST_SUITE=integration
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,27 @@ matrix:
   include:
     - php: 7.3
       env:
+       - MAGENTO_VERSION=2.4-develop
+       - TEST_SUITE=integration
+    - php: 7.3
+      env:
+       - MAGENTO_VERSION=2.4-develop
+       - TEST_SUITE=unit
+    - php: 7.3
+      env:
        - MAGENTO_VERSION=2.3
        - TEST_SUITE=integration
     - php: 7.3
       env:
        - MAGENTO_VERSION=2.3
        - TEST_SUITE=unit
-    - php: 7.3
+    - php: 7.2
       env:
-       - MAGENTO_VERSION=2.3-develop
+       - MAGENTO_VERSION=2.4-develop
        - TEST_SUITE=integration
-    - php: 7.3
+    - php: 7.2
       env:
-       - MAGENTO_VERSION=2.3-develop
+       - MAGENTO_VERSION=2.4-develop
        - TEST_SUITE=unit
     - php: 7.2
       env:
@@ -37,30 +45,14 @@ matrix:
       env:
        - MAGENTO_VERSION=2.3
        - TEST_SUITE=unit
-    - php: 7.2
-      env:
-       - MAGENTO_VERSION=2.3-develop
-       - TEST_SUITE=integration
-    - php: 7.2
-      env:
-       - MAGENTO_VERSION=2.3-develop
-       - TEST_SUITE=unit
     - php: 7.1
       env:
-       - MAGENTO_VERSION=2.3-develop
+       - MAGENTO_VERSION=2.3
        - TEST_SUITE=integration
     - php: 7.1
       env:
-       - MAGENTO_VERSION=2.3-develop
+       - MAGENTO_VERSION=2.3
        - TEST_SUITE=unit
-    - php: 7.1
-      env:
-        - MAGENTO_VERSION=2.2-develop
-        - TEST_SUITE=integration
-    - php: 7.1
-      env:
-        - MAGENTO_VERSION=2.2-develop
-        - TEST_SUITE=unit
     - php: 7.1
       env:
         - MAGENTO_VERSION=2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,15 @@ matrix:
     - php: 7.3
       env:
        - MAGENTO_VERSION=2.4-develop
+       - TEST_SUITE=coverage
+    - php: 7.3
+      env:
+       - MAGENTO_VERSION=2.4-develop
        - TEST_SUITE=integration
     - php: 7.3
       env:
        - MAGENTO_VERSION=2.4-develop
        - TEST_SUITE=unit
-       - TEST_COVERAGE=true
     - php: 7.3
       env:
        - MAGENTO_VERSION=2.3
@@ -71,6 +74,7 @@ cache:
   directories:
     - $HOME/.composer/cache
 before_script: ./.travis/before_script.sh
-script: phpunit -c magento2/dev/tests/$TEST_SUITE
+script:
+    - if [[ $TEST_SUITE == 'coverage' ]]; then phpunit -c magento2/dev/tests/unit && phpunit -c magento2/dev/tests/integration ; else phpunit -c magento2/dev/tests/$TEST_SUITE ; fi
 after_success:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry php magento2/vendor/php-coveralls/php-coveralls/bin/php-coveralls -v ; fi
+  - if [[ $TEST_SUITE == 'coverage' ]]; then travis_retry php magento2/vendor/php-coveralls/php-coveralls/bin/php-coveralls -v ; fi

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -10,7 +10,7 @@ smtp-sink -d "%d.%H.%M.%S" localhost:2500 1000 &
 echo 'sendmail_path = "/usr/sbin/sendmail -t -i "' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/sendmail.ini
 
 # disable xdebug and adjust memory limit
-echo > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+test "$TEST_COVERAGE" || echo > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
 echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 phpenv rehash;
 
@@ -57,3 +57,7 @@ case $TEST_SUITE in
         cp vendor/$COMPOSER_PACKAGE_NAME/Test/Unit/phpunit.xml.dist dev/tests/unit/phpunit.xml
         ;;
 esac
+
+if test "$TEST_COVERAGE"; then
+    composer require --dev --no-interaction php-coveralls/php-coveralls
+fi

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -23,16 +23,16 @@ git clone --branch $MAGENTO_VERSION --depth=1 https://github.com/magento/magento
 cd magento2
 
 # add composer package under test, composer require will trigger update/install
+MY_REPO_SLUG=${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}
+MY_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
+composer config minimum-stability dev
+composer config repositories.travis_to_test git https://github.com/${MY_REPO_SLUG}.git
 case $TRAVIS_BRANCH in
     "1.x" | "0.x")
-        composer config minimum-stability dev
-        composer config repositories.travis_to_test git https://github.com/$TRAVIS_REPO_SLUG.git
-        composer require ${COMPOSER_PACKAGE_NAME}:${TRAVIS_BRANCH}-dev\#{$TRAVIS_COMMIT}
+        composer require ${COMPOSER_PACKAGE_NAME}:${MY_BRANCH}-dev\#{$TRAVIS_COMMIT}
         ;;
     *)
-        composer config minimum-stability dev
-        composer config repositories.travis_to_test git https://github.com/$TRAVIS_REPO_SLUG.git
-        composer require ${COMPOSER_PACKAGE_NAME}:dev-${TRAVIS_BRANCH}\#{$TRAVIS_COMMIT}
+        composer require ${COMPOSER_PACKAGE_NAME}:dev-${MY_BRANCH}\#{$TRAVIS_COMMIT}
         ;;
 esac
 

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -27,7 +27,7 @@ MY_REPO_SLUG=${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}
 MY_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
 composer config minimum-stability dev
 composer config repositories.travis_to_test git https://github.com/${MY_REPO_SLUG}.git
-case $TRAVIS_BRANCH in
+case $MY_BRANCH in
     "1.x" | "0.x")
         composer require ${COMPOSER_PACKAGE_NAME}:${MY_BRANCH}-dev\#{$TRAVIS_COMMIT}
         ;;

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -10,7 +10,7 @@ smtp-sink -d "%d.%H.%M.%S" localhost:2500 1000 &
 echo 'sendmail_path = "/usr/sbin/sendmail -t -i "' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/sendmail.ini
 
 # disable xdebug and adjust memory limit
-test "$TEST_COVERAGE" || echo > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+test "$TEST_SUITE" = "coverage" || echo > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
 echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 phpenv rehash;
 
@@ -37,10 +37,10 @@ case $TRAVIS_BRANCH in
 esac
 
 # prepare for test suite
+cp vendor/$COMPOSER_PACKAGE_NAME/Test/Integration/phpunit.xml.dist dev/tests/integration/phpunit.xml
+cp vendor/$COMPOSER_PACKAGE_NAME/Test/Unit/phpunit.xml.dist dev/tests/unit/phpunit.xml
 case $TEST_SUITE in
-    integration)
-        cp vendor/$COMPOSER_PACKAGE_NAME/Test/Integration/phpunit.xml.dist dev/tests/integration/phpunit.xml
-
+    integration|coverage)
         cd dev/tests/integration
 
         # create database and move db config into place
@@ -53,11 +53,8 @@ case $TEST_SUITE in
 
         cd ../../..
         ;;
-    unit)
-        cp vendor/$COMPOSER_PACKAGE_NAME/Test/Unit/phpunit.xml.dist dev/tests/unit/phpunit.xml
-        ;;
 esac
 
-if test "$TEST_COVERAGE"; then
+if test "$TEST_SUITE" = "coverage"; then
     composer require --dev --no-interaction php-coveralls/php-coveralls
 fi

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
     <img src="https://travis-ci.org/Ethan3600/magento2-CronjobManager.svg?branch=1.x"
          alt="Travis CI build status">
   </a>
+  <a href='https://coveralls.io/github/Ethan3600/magento2-CronjobManager'>
+    <img src='https://coveralls.io/repos/github/Ethan3600/magento2-CronjobManager/badge.svg' alt='Coverage Status' />
+  </a>
 </p>
 
 ## Installation

--- a/Test/Integration/ErrorNotificationEmailTest.php
+++ b/Test/Integration/ErrorNotificationEmailTest.php
@@ -7,9 +7,9 @@ use EthanYehuda\CronjobManager\Model\ErrorNotificationEmail;
 use Magento\Cron\Model\Schedule;
 use Magento\Framework\Mail\Message;
 use Magento\Framework\Mail\Template\TransportBuilder;
-use Magento\TestFramework\ObjectManager;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\Mail\Template\TransportBuilderMock;
+use Magento\TestFramework\ObjectManager;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -129,6 +129,7 @@ class ErrorNotificationEmailTest extends TestCase
     private function andEmailShouldHaveContents(Message $sentMessage, array $expectedContents): void
     {
         $content = $sentMessage->getBody()->getParts()[0]->getContent();
+        $content = \Zend_Mime_Decode::decodeQuotedPrintable($content);
         foreach ($expectedContents as $expectedKey => $expectedContent) {
             $this->assertContains($expectedContent, $content, "Content should contain $expectedKey");
         }

--- a/Test/Integration/phpunit.xml.dist
+++ b/Test/Integration/phpunit.xml.dist
@@ -64,4 +64,7 @@
         <listener class="Magento\TestFramework\Event\PhpUnit"/>
         <listener class="Magento\TestFramework\ErrorLog\Listener"/>
     </listeners>
+    <logging>
+        <log type="coverage-clover" target="tmp/clover.xml"/>
+    </logging>
 </phpunit>

--- a/Test/Unit/phpunit.xml.dist
+++ b/Test/Unit/phpunit.xml.dist
@@ -15,14 +15,9 @@
     </php>
     <filter>
         <whitelist addUncoveredFilesFromWhiteList="true">
-            <directory suffix=".php">../../../app/code/*</directory>
-            <directory suffix=".php">../../../lib/internal/Magento</directory>
-            <directory suffix=".php">../../../setup/src/*</directory>
+            <directory suffix=".php">../../../vendor/ethanyehuda/magento2-cronjobmanager</directory>
             <exclude>
-                <directory>../../../app/code/*/*/Test</directory>
-                <directory>../../../lib/internal/*/*/Test</directory>
-                <directory>../../../lib/internal/*/*/*/Test</directory>
-                <directory>../../../setup/src/*/*/Test</directory>
+                <directory>../../../vendor/ethanyehuda/magento2-cronjobmanager/Test</directory>
             </exclude>
         </whitelist>
     </filter>
@@ -30,17 +25,6 @@
         <listener class="Magento\Framework\TestFramework\Unit\Listener\ReplaceObjectManager"/>
     </listeners>
     <logging>
-        <!--coverage_html_placeholder
-            <log type="coverage-html" target="{{coverage_dir}}/test-reports/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        coverage_html_placeholder-->
-        <!--coverage_cov_placeholder
-            <log type="coverage-php" target="{{coverage_dir}}/test-reports/coverage.cov"/>
-        coverage_cov_placeholder-->
-        <!--coverage_clover_placeholder
-            <log type="coverage-clover" target="{{coverage_dir}}/test-reports/phpunit.coverage.xml"/>
-        coverage_clover_placeholder-->
-        <!--coverage_crap4j_placeholder
-            <log type="coverage-crap4j" target="{{coverage_dir}}/test-reports/phpunit.crap4j.xml"/>
-        coverage_crap4j_placeholder-->
+        <log type="coverage-clover" target="clover.xml"/>
     </logging>
 </phpunit>

--- a/Test/Unit/phpunit.xml.dist
+++ b/Test/Unit/phpunit.xml.dist
@@ -25,6 +25,6 @@
         <listener class="Magento\Framework\TestFramework\Unit\Listener\ReplaceObjectManager"/>
     </listeners>
     <logging>
-        <log type="coverage-clover" target="clover.xml"/>
+        <log type="coverage-clover" target="tmp/clover.xml"/>
     </logging>
 </phpunit>

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
         "php": "~7.1.0||~7.2.0||~7.3.0",
         "magento/framework": "~100.3.0-dev|~101.0.0|~102.0.0"
     },
+    "require-dev": {
+        "ext-pcntl": "*"
+    },
     "type": "magento2-module",
     "license": "OSL-3.0",
     "autoload": {


### PR DESCRIPTION
Integration tests are currently failing because email content hasn't been decoded before it is compared to the expected output. This pull request solves that problem by adjusting the test.

This pull request also updates the branch names & PHP versions for Magento, and enables support for coveralls.io to help track unit test code coverage going forward.