### PR TITLE
Fix PHP Fatal error on invalid job_code

### DIFF
--- a/Api/ScheduleManagementInterface.php
+++ b/Api/ScheduleManagementInterface.php
@@ -4,6 +4,7 @@ namespace EthanYehuda\CronjobManager\Api;
 
 use Magento\Cron\Model\Schedule;
 use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 interface ScheduleManagementInterface
@@ -26,7 +27,8 @@ interface ScheduleManagementInterface
     /**
      * @param string $jobCode
      * @param string[]|null $groups
-     * @return string|null
+     * @return string
+     * @throws LocalizedException
      */
     public function getGroupId(string $jobCode, $groups = null);
 

--- a/Model/ScheduleManagement.php
+++ b/Model/ScheduleManagement.php
@@ -9,6 +9,7 @@ use Magento\Cron\Model\ConfigInterface;
 use EthanYehuda\CronjobManager\Api\JobManagementInterface;
 use Magento\Cron\Model\ScheduleFactory;
 use Magento\Cron\Model\Schedule;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Stdlib\DateTime\DateTime;
 
 class ScheduleManagement implements ScheduleManagementInterface
@@ -109,7 +110,10 @@ class ScheduleManagement implements ScheduleManagementInterface
             }
         }
 
-        return null;
+        throw new LocalizedException(__(
+            'No such job: %jobCode',
+            ['jobCode' => $jobCode]
+        ));
     }
 
     public function flush(): bool

--- a/Test/Integration/Model/ScheduleManagementTest.php
+++ b/Test/Integration/Model/ScheduleManagementTest.php
@@ -5,6 +5,7 @@ namespace Test\Integration\Model;
 
 use EthanYehuda\CronjobManager\Api\ScheduleManagementInterface;
 use Magento\Cron\Model\Schedule;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\ObjectManager;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,20 @@ class ScheduleManagementTest extends TestCase
         $this->objectManager = Bootstrap::getObjectManager();
         $this->scheduleManagement = $this->objectManager->get(ScheduleManagementInterface::class);
     }
+
+    public function testGetGroupIdWithValidJobCode()
+    {
+        $groupId = $this->scheduleManagement->getGroupId('backend_clean_cache');
+        $this->assertSame('default', $groupId);
+    }
+
+    public function testGetGroupIdWithInvalidJobCode()
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('No such job: not_valid');
+        $this->scheduleManagement->getGroupId('not_valid');
+    }
+
     public function testKillRequestForRunningJobSucceeds()
     {
         $this->givenRunningSchedule($schedule);


### PR DESCRIPTION
When running `bin/magento cronmanager:runjob no_such_job` the following error is encountered: 
>Fatal error: Uncaught TypeError: Return value of EthanYehuda\CronjobManager\Model\ScheduleManagement::getGroupId() must be of the type string, null returned in /var/www/html/vendor/ethanyehuda/magento2-cronjobmanager/Model/ScheduleManagement.php:112

This is because the return type declaration for `EthanYehuda\CronjobManager\Model\ScheduleManagement::getGroupId()` does not permit `null` to be returned. This pull request replaces the invalid return with an exception which can be caught as needed.