### PR TITLE
Ensure process ID is always saved with running job

### DIFF
--- a/Plugin/Cron/Model/SchedulePlugin.php
+++ b/Plugin/Cron/Model/SchedulePlugin.php
@@ -4,13 +4,25 @@ declare(strict_types=1);
 namespace EthanYehuda\CronjobManager\Plugin\Cron\Model;
 
 use Magento\Cron\Model\Schedule;
+use Magento\Cron\Model\ResourceModel\Schedule as ScheduleResource;
 
 class SchedulePlugin
 {
+    /**
+     * @var ScheduleResource
+     */
+    protected $scheduleResource;
+
+    public function __construct(ScheduleResource $scheduleResource)
+    {
+        $this->scheduleResource = $scheduleResource;
+    }
+
     public function afterTryLockJob(Schedule $subject, bool $result)
     {
         if ($result) {
             $subject->setData('pid', \getmypid());
+            $this->scheduleResource->save($subject);
         }
         return $result;
     }


### PR DESCRIPTION
With the release of Magento version 2.3.5-p1, tests in Travis CI started failing. (With v2.3.4 there were no such errors.) 
This pull request should fix the failure, by always saving schedule object after successfully obtaining a lock and setting the `pid` attribute in our plugin.