### PR TITLE
Update tests for compatibility with Magento v2.4-develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,6 @@ matrix:
        - TEST_SUITE=unit
     - php: 7.2
       env:
-       - MAGENTO_VERSION=2.4-develop
-       - TEST_SUITE=integration
-    - php: 7.2
-      env:
-       - MAGENTO_VERSION=2.4-develop
-       - TEST_SUITE=unit
-    - php: 7.2
-      env:
        - MAGENTO_VERSION=2.3
        - TEST_SUITE=integration
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,10 @@ addons:
 language: php
 matrix:
   include:
-    - php: 7.4
+    - php: 7.3
       env:
        - MAGENTO_VERSION=2.4-develop
        - TEST_SUITE=coverage
-    - php: 7.4
-      env:
-       - MAGENTO_VERSION=2.4-develop
-       - TEST_SUITE=integration
-    - php: 7.4
-      env:
-       - MAGENTO_VERSION=2.4-develop
-       - TEST_SUITE=unit
     - php: 7.3
       env:
        - MAGENTO_VERSION=2.4-develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: required
 dist: trusty
 group: edge
+services:
+  - elasticsearch
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,18 @@ addons:
 language: php
 matrix:
   include:
-    - php: 7.3
+    - php: 7.4
       env:
        - MAGENTO_VERSION=2.4-develop
        - TEST_SUITE=coverage
+    - php: 7.4
+      env:
+       - MAGENTO_VERSION=2.4-develop
+       - TEST_SUITE=integration
+    - php: 7.4
+      env:
+       - MAGENTO_VERSION=2.4-develop
+       - TEST_SUITE=unit
     - php: 7.3
       env:
        - MAGENTO_VERSION=2.4-develop

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -16,6 +16,9 @@ phpenv rehash;
 
 composer selfupdate
 
+# Allow elasticsearch service to start. See https://docs.travis-ci.com/user/database-setup/#elasticsearch
+sleep 10
+
 # clone main magento github repository
 git clone --branch $MAGENTO_VERSION --depth=1 https://github.com/magento/magento2
 

--- a/Test/Integration/CleanRunningJobsTest.php
+++ b/Test/Integration/CleanRunningJobsTest.php
@@ -19,14 +19,17 @@ use Magento\Framework\Event;
 class CleanRunningJobsTest extends TestCase
 {
     const NOW = '2019-02-09 18:33:00';
+
     /**
      * @var ObjectManager
      */
     private $objectManager;
+
     /**
      * @var Event\ManagerInterface
      */
     private $eventManager;
+
     /**
      * @var FakeClock
      */
@@ -34,7 +37,7 @@ class CleanRunningJobsTest extends TestCase
 
     const DEAD_PID = 99999999;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->objectManager->configure(['preferences' => [Clock::class => FakeClock::class]]);

--- a/Test/Integration/Controller/Adminhtml/Manage/CreateTest.php
+++ b/Test/Integration/Controller/Adminhtml/Manage/CreateTest.php
@@ -15,6 +15,10 @@ class CreateTest extends AbstractBackendController
         $this->dispatch($this->uri);
         $result = $this->getResponse()->getBody();
 
-        $this->assertStringContainsString('<title>Create Cron Job / Tools / System / Magento Admin</title>', $result);
+        if (\method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString('<title>Create Cron Job / Tools / System / Magento Admin</title>', $result);
+        } else {
+            $this->assertContains('<title>Create Cron Job / Tools / System / Magento Admin</title>', $result);
+        }
     }
 }

--- a/Test/Integration/Controller/Adminhtml/Manage/CreateTest.php
+++ b/Test/Integration/Controller/Adminhtml/Manage/CreateTest.php
@@ -15,6 +15,6 @@ class CreateTest extends AbstractBackendController
         $this->dispatch($this->uri);
         $result = $this->getResponse()->getBody();
 
-        $this->assertContains('<title>Create Cron Job / Tools / System / Magento Admin</title>', $result);
+        $this->assertStringContainsString('<title>Create Cron Job / Tools / System / Magento Admin</title>', $result);
     }
 }

--- a/Test/Integration/Controller/Adminhtml/Manage/EditTest.php
+++ b/Test/Integration/Controller/Adminhtml/Manage/EditTest.php
@@ -15,6 +15,10 @@ class EditTest extends AbstractBackendController
         $this->dispatch($this->uri);
         $result = $this->getResponse()->getBody();
 
-        $this->assertStringContainsString('<title>Edit Cron Job / Tools / System / Magento Admin</title>', $result);
+        if (\method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString('<title>Edit Cron Job / Tools / System / Magento Admin</title>', $result);
+        } else {
+            $this->assertContains('<title>Edit Cron Job / Tools / System / Magento Admin</title>', $result);
+        }
     }
 }

--- a/Test/Integration/Controller/Adminhtml/Manage/EditTest.php
+++ b/Test/Integration/Controller/Adminhtml/Manage/EditTest.php
@@ -15,6 +15,6 @@ class EditTest extends AbstractBackendController
         $this->dispatch($this->uri);
         $result = $this->getResponse()->getBody();
 
-        $this->assertContains('<title>Edit Cron Job / Tools / System / Magento Admin</title>', $result);
+        $this->assertStringContainsString('<title>Edit Cron Job / Tools / System / Magento Admin</title>', $result);
     }
 }

--- a/Test/Integration/Controller/Adminhtml/Manage/IndexTest.php
+++ b/Test/Integration/Controller/Adminhtml/Manage/IndexTest.php
@@ -18,7 +18,11 @@ class IndexTest extends AbstractBackendController
         $this->dispatch($this->uri);
         $result = $this->getResponse()->getBody();
 
-        $this->assertStringContainsString('<title>Cron Job Dashboard / Tools / System / Magento Admin</title>', $result);
+        if (\method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString('<title>Cron Job Dashboard / Tools / System / Magento Admin</title>', $result);
+        } else {
+            $this->assertContains('<title>Cron Job Dashboard / Tools / System / Magento Admin</title>', $result);
+        }
     }
 
     public static function loadDataFixtureCron()

--- a/Test/Integration/Controller/Adminhtml/Manage/IndexTest.php
+++ b/Test/Integration/Controller/Adminhtml/Manage/IndexTest.php
@@ -18,7 +18,7 @@ class IndexTest extends AbstractBackendController
         $this->dispatch($this->uri);
         $result = $this->getResponse()->getBody();
 
-        $this->assertContains('<title>Cron Job Dashboard / Tools / System / Magento Admin</title>', $result);
+        $this->assertStringContainsString('<title>Cron Job Dashboard / Tools / System / Magento Admin</title>', $result);
     }
 
     public static function loadDataFixtureCron()

--- a/Test/Integration/ErrorNotificationEmailTest.php
+++ b/Test/Integration/ErrorNotificationEmailTest.php
@@ -133,7 +133,7 @@ class ErrorNotificationEmailTest extends TestCase
         $content = $sentMessage->getBody()->getParts()[0]->getContent();
         $content = \Zend_Mime_Decode::decodeQuotedPrintable($content);
         foreach ($expectedContents as $expectedKey => $expectedContent) {
-            $this->assertContains($expectedContent, $content, "Content should contain $expectedKey");
+            $this->assertStringContainsString($expectedContent, $content, "Content should contain $expectedKey");
         }
     }
 }

--- a/Test/Integration/ErrorNotificationEmailTest.php
+++ b/Test/Integration/ErrorNotificationEmailTest.php
@@ -133,7 +133,11 @@ class ErrorNotificationEmailTest extends TestCase
         $content = $sentMessage->getBody()->getParts()[0]->getContent();
         $content = \Zend_Mime_Decode::decodeQuotedPrintable($content);
         foreach ($expectedContents as $expectedKey => $expectedContent) {
-            $this->assertStringContainsString($expectedContent, $content, "Content should contain $expectedKey");
+            if (\method_exists($this, 'assertStringContainsString')) {
+                $this->assertStringContainsString($expectedContent, $content, "Content should contain $expectedKey");
+            } else {
+                $this->assertContains($expectedContent, $content, "Content should contain $expectedKey");
+            }
         }
     }
 }

--- a/Test/Integration/ErrorNotificationEmailTest.php
+++ b/Test/Integration/ErrorNotificationEmailTest.php
@@ -22,16 +22,18 @@ class ErrorNotificationEmailTest extends TestCase
      * @var ObjectManager
      */
     private $objectManager;
+
     /**
      * @var ErrorNotificationEmail
      */
     private $errorNotificationEmail;
+
     /**
      * @var \Magento\TestFramework\Mail\Template\TransportBuilderMock
      */
     private $transportBuilder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->transportBuilder = $this->objectManager->get(TransportBuilderMock::class);

--- a/Test/Integration/ErrorNotificationTest.php
+++ b/Test/Integration/ErrorNotificationTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\TestCase;
 class ErrorNotificationTest extends TestCase
 {
     const NOW = '2019-02-09 18:33:00';
+
     /**
      * @var ObjectManager
      */
@@ -37,28 +38,33 @@ class ErrorNotificationTest extends TestCase
      * @var ScheduleManagementInterface
      */
     private $scheduleManagement;
+
     /**
      * @var ScheduleRepositoryInterface
      */
     private $scheduleRepository;
+
     /**
      * @var FakeClock
      */
     private $clock;
+
     /**
      * @var \Magento\Framework\App\CacheInterface
      */
     private $cache;
+
     /**
      * @var ErrorNotification|\PHPUnit_Framework_MockObject_MockObject
      */
     private $errorNotification;
+
     /**
      * @var ProcessCronQueueObserver
      */
     private $processCronQueueObserver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->objectManager->configure(

--- a/Test/Integration/Model/ManagerTest.php
+++ b/Test/Integration/Model/ManagerTest.php
@@ -21,10 +21,10 @@ class ManagerTest extends TestCase
      */
     private $scheduleFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $objectManager = Bootstrap::getObjectManager();
-        
+
         $this->manager = $objectManager->create(Manager::class);
         $this->scheduleFactory = $objectManager->create(ScheduleFactory::class);
     }

--- a/Test/Integration/Model/ManagerTest.php
+++ b/Test/Integration/Model/ManagerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Magento\TestFramework\Helper\Bootstrap;
 use EthanYehuda\CronjobManager\Model\Manager;
 use Magento\Cron\Model\ScheduleFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 class ManagerTest extends TestCase
 {
@@ -50,11 +51,10 @@ class ManagerTest extends TestCase
         $this->assertEquals(Schedule::STATUS_SUCCESS, $cron->getStatus());
     }
 
-    /**
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     */
     public function testSaveCronInvalidId()
     {
+        $this->expectException(NoSuchEntityException::class);
+        $this->expectExceptionMessage('The Schedule with the "99999" ID doesn\'t exist');
         $this->manager->saveCronJob(99999);
     }
 
@@ -69,11 +69,10 @@ class ManagerTest extends TestCase
         $this->assertNull($cron->getScheduleId());
     }
 
-    /**
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     */
     public function testDeleteInvalidId()
     {
+        $this->expectException(NoSuchEntityException::class);
+        $this->expectExceptionMessage('The Schedule with the "99999" ID doesn\'t exist');
         $this->manager->deleteCronJob(99999);
     }
 

--- a/Test/Integration/Model/ScheduleManagementTest.php
+++ b/Test/Integration/Model/ScheduleManagementTest.php
@@ -26,11 +26,12 @@ class ScheduleManagementTest extends TestCase
 
     const NOW = '2019-02-09 18:33:00';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->scheduleManagement = $this->objectManager->get(ScheduleManagementInterface::class);
     }
+
     public function testKillRequestForRunningJobSucceeds()
     {
         $this->givenRunningSchedule($schedule);

--- a/Test/Integration/ProcessIdTest.php
+++ b/Test/Integration/ProcessIdTest.php
@@ -18,10 +18,11 @@ class ProcessIdTest extends TestCase
      */
     private $objectManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
     }
+
     public function testProcessIdSavedOnStart()
     {
         $this->givenPid($pid);
@@ -29,6 +30,7 @@ class ProcessIdTest extends TestCase
         $this->whenTryLockJob($schedule);
         $this->thenScheduleIsSavedWithPid($schedule, $pid);
     }
+
     public function testProcessIdMaintainedAfterSuccesfulRun()
     {
         $this->givenPid($pid);

--- a/Test/Integration/ProcessKillRequestsTest.php
+++ b/Test/Integration/ProcessKillRequestsTest.php
@@ -21,32 +21,38 @@ use PHPUnit\Framework\TestCase;
 class ProcessKillRequestsTest extends TestCase
 {
     const NOW = '2019-02-09 18:33:00';
+
     /**
      * @var int
      */
     private $childPid = 0;
+
     /**
      * @var ObjectManager
      */
     private $objectManager;
+
     /**
      * @var Event\ManagerInterface
      */
     private $eventManager;
+
     /**
      * @var ScheduleManagementInterface
      */
     private $scheduleManagement;
+
     /**
      * @var ProcessManagement
      */
     private $processManagement;
+
     /**
      * @var FakeClock
      */
     private $clock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->objectManager->configure(['preferences' => [Clock::class => FakeClock::class]]);
@@ -57,7 +63,7 @@ class ProcessKillRequestsTest extends TestCase
         $this->processManagement = $this->objectManager->get(ProcessManagement::class);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         /*
          * Take care of children that we failed to kill
@@ -78,7 +84,6 @@ class ProcessKillRequestsTest extends TestCase
 
     private function givenRunningScheduleWithKillRequest(&$schedule, int $timestamp)
     {
-
         /** @var Schedule $schedule */
         $schedule = $this->objectManager->create(Schedule::class);
         $schedule->setStatus(Schedule::STATUS_RUNNING);

--- a/Test/Integration/phpunit.xml.dist
+++ b/Test/Integration/phpunit.xml.dist
@@ -14,7 +14,7 @@
     </testsuites>
     <!-- Code coverage filters -->
     <filter>
-        <whitelist addUncoveredFilesFromWhiteList="true">
+        <whitelist>
             <directory suffix=".php">../../../vendor/ethanyehuda/magento2-cronjobmanager</directory>
             <exclude>
                 <directory>../../../vendor/ethanyehuda/magento2-cronjobmanager/Test</directory>

--- a/Test/Unit/Console/Command/KillJobTest.php
+++ b/Test/Unit/Console/Command/KillJobTest.php
@@ -35,7 +35,7 @@ class KillJobTest extends TestCase
     private $mockFilterBuilder;
     private $mockFilterGroupBuilder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockState = $this->getMockBuilder(State::class)->setConstructorArgs([
             $this->createMock(ScopeInterface::class),
@@ -304,4 +304,3 @@ class KillJobTest extends TestCase
         return $mockSchedules;
     }
 }
-

--- a/Test/Unit/Console/Command/RunjobTest.php
+++ b/Test/Unit/Console/Command/RunjobTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace EthanYehuda\CronjobManager\Test\Unit\Console\Command;
+
+use EthanYehuda\CronjobManager\Console\Command\Runjob;
+use EthanYehuda\CronjobManager\Model\Cron\Runner;
+use Magento\Framework\App\ObjectManagerFactory;
+use Magento\Framework\Console\Cli;
+use Magento\Framework\ObjectManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class RunjobTest extends TestCase
+{
+    protected $runner;
+    protected $command;
+
+    protected function setUp(): void
+    {
+        $this->runner = $this->createMock(Runner::class);
+
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects($this->any())
+            ->method('create')
+            ->willReturn($this->runner);
+
+        $objectManagerFactory = $this->createMock(ObjectManagerFactory::class);
+        $objectManagerFactory->expects($this->any())
+            ->method('create')
+            ->willReturn($objectManager);
+
+        $command = new Runjob($objectManagerFactory);
+        $this->commandTester = new CommandTester($command);
+    }
+
+    public function testExecuteThrowsWithoutRequiredArgument()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "job_code").');
+
+        $this->commandTester->execute([]);
+    }
+
+    public function testExecute()
+    {
+        $jobCode = 'good_job';
+        $resultCode = Cli::RETURN_SUCCESS;
+        $resultMessage = "$jobCode successfully ran";
+
+        $this->runner->expects($this->once())
+            ->method('runCron')
+            ->with($jobCode)
+            ->willReturn([$resultCode, $resultMessage]);
+
+        $commandResult = $this->commandTester->execute([
+            'job_code' => $jobCode,
+        ]);
+        $this->assertSame($resultCode, $commandResult);
+        $this->assertSame($resultMessage . PHP_EOL, $this->commandTester->getDisplay());
+    }
+}

--- a/Test/Unit/phpunit.xml.dist
+++ b/Test/Unit/phpunit.xml.dist
@@ -14,7 +14,7 @@
         <ini name="xdebug.max_nesting_level" value="200"/>
     </php>
     <filter>
-        <whitelist addUncoveredFilesFromWhiteList="true">
+        <whitelist>
             <directory suffix=".php">../../../vendor/ethanyehuda/magento2-cronjobmanager</directory>
             <exclude>
                 <directory>../../../vendor/ethanyehuda/magento2-cronjobmanager/Test</directory>

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "A module for managing scheduled cron jobs from magento's admin panel",
     "require": {
         "php": "~7.1.0||~7.2.0||~7.3.0||~7.4.0",
+        "ext-posix": "*",
         "magento/framework": "~100.3.0-dev|~101.0.0|~102.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ethanyehuda/magento2-cronjobmanager",
     "description": "A module for managing scheduled cron jobs from magento's admin panel",
     "require": {
-        "php": "~7.1.0||~7.2.0||~7.3.0",
+        "php": "~7.1.0||~7.2.0||~7.3.0||~7.4.0",
         "magento/framework": "~100.3.0-dev|~101.0.0|~102.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Unit & integration tests are currently failing with recent changes in `2.4-develop` branch. This pull request resolves the unit test failure.

The failure for integration tests relates to Magento v2.4 requiring elasticsearch to be installed and available, but I have not looked into how to set this up in Travis CI yet.

Magento v2.4 will not support PHP v7.2, so these tests have been removed too.