### PR TITLE
Sort jobs by job_code for display

### DIFF
--- a/Model/Schedule/Source/Schedule.php
+++ b/Model/Schedule/Source/Schedule.php
@@ -40,6 +40,10 @@ class Schedule implements OptionSourceInterface
             array_push($options, $option);
         }
 
+        \usort($options, function ($a, $b) {
+            return \strnatcmp($a['label'], $b['label']);
+        });
+
         return $options;
     }
 

--- a/Model/ScheduleManagement.php
+++ b/Model/ScheduleManagement.php
@@ -68,7 +68,11 @@ class ScheduleManagement implements ScheduleManagementInterface
 
     public function listJobs(): array
     {
-        return $this->config->getJobs();
+        $jobList = $this->config->getJobs();
+        foreach ($jobList as &$jobs) {
+            \ksort($jobs);
+        }
+        return $jobList;
     }
 
     public function createSchedule(string $jobCode, $time = null): Schedule


### PR DESCRIPTION
This pull request sorts the following lists of `job_code`s in alphabetical order:
- `bin/magento cronmanager:showjobs`
- Admin -> System -> Cron Job Manager -> (Dashboard) -> Filters -> Job Code
- Admin -> System -> Cron Job Manager -> Job Configuration -> Filters -> Job Code