### PR TITLE
Fix error on save and continue edit

### DIFF
--- a/Controller/Adminhtml/Config/Job/Save.php
+++ b/Controller/Adminhtml/Config/Job/Save.php
@@ -76,7 +76,7 @@ class Save extends Action
         if (!isset($params['back'])) {
             $this->_redirect("*/config/index/");
         } else {
-            unset($params['key'], $params['form_key']);
+            unset($params['key'], $params['form_key'], $params['frequency']);
             $this->_redirect("*/config/{$params['back']}/", $params);
         }
     }


### PR DESCRIPTION
If you save and continue edit a cron job the `params['frequency']` value has to be unset to not be included in the URL

Fixes #148 
