### PR TITLE
Issue displaying date type columns on main grid

### DIFF
--- a/view/adminhtml/ui_component/cronjobmanager_manage_grid.xml
+++ b/view/adminhtml/ui_component/cronjobmanager_manage_grid.xml
@@ -206,7 +206,6 @@
 					<item name="dataType" xsi:type="string">date</item>
 					<item name="label" xsi:type="string" translate="true">Created Date</item>
 					<item name="draggable" xsi:type="boolean">false</item>
-					<item name="timezone" xsi:type="boolean">true</item>
 				</item>
 			</argument>
 		</column>
@@ -218,7 +217,6 @@
 					<item name="dataType" xsi:type="string">date</item>
 					<item name="label" xsi:type="string" translate="true">Scheduled Date</item>
 					<item name="draggable" xsi:type="boolean">false</item>
-					<item name="timezone" xsi:type="boolean">true</item>
 				</item>
 			</argument>
 		</column>
@@ -231,7 +229,6 @@
 					<item name="dataType" xsi:type="string">date</item>
 					<item name="label" xsi:type="string" translate="true">Executed Date</item>
 					<item name="draggable" xsi:type="boolean">false</item>
-					<item name="timezone" xsi:type="boolean">true</item>
 				</item>
 			</argument>
 		</column>
@@ -243,7 +240,6 @@
 					<item name="dataType" xsi:type="string">date</item>
 					<item name="label" xsi:type="string" translate="true">Finished Date</item>
 					<item name="draggable" xsi:type="boolean">false</item>
-					<item name="timezone" xsi:type="boolean">true</item>
 				</item>
 			</argument>
 		</column>


### PR DESCRIPTION
Probably caused by the Magento 2.4.0 update, it seems that using the "timezone" configuration in the date type columns results in a knockout.js error visible in console, that makes impossible to view the grid correctly. Removing it seems to work fine.
The error is the following:
```
Uncaught TypeError: "Unable to process binding "text: function(){return $col.getLabel($row()) }"
Message: (intermediate value).toLowerCase is not a function" in file moment-timezone-with-data.js
```