### PR TITLE
Include store URL in error emails

### DIFF
--- a/view/adminhtml/email/cronjob_error.html
+++ b/view/adminhtml/email/cronjob_error.html
@@ -17,3 +17,6 @@
         </tr>
     </table>
 </p>
+<p>
+    {{store url=""}}
+</p>


### PR DESCRIPTION
Sometimes it's hard to work out which website is sending me error emails. Including the URL in the email will help identify production websites from staging & development websites.