### PR TITLE
Fix filter in config grid

### DIFF
--- a/Ui/Component/Listing/DataProviders/Cronjobmanager/Config/Grid.php
+++ b/Ui/Component/Listing/DataProviders/Cronjobmanager/Config/Grid.php
@@ -128,6 +128,7 @@ class Grid extends AbstractDataProvider
                     return strpos($v[$reg['field']], $reg['condition']) !== false;
                 };
                 $filterRegistry['condition'] = trim($filterRegistry['condition'], "%");
+                $filterRegistry['condition'] = str_replace(['\%', '\_'], ['%', '_'], $filterRegistry['condition']);
                 $this->filterRegistry[] = $filterRegistry;
                 break;
             case 'eq':


### PR DESCRIPTION
When using the 'group' or 'job code' filters in the configuration grid, searching for any string containing an underscore results in an empty grid with no records found, even if there should be. This is because the search string is being escaped for use in an SQL `LIKE` clause, however the string then being compared with `strpos()`. This pull request removes the escaping to allow searching the grid to work as expected.