### PR TITLE
Run Magento Coding Standard in GitHub Action

### DIFF
--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -1,0 +1,12 @@
+name: ExtDN M2 Coding Standard
+on:
+  push:
+  pull_request:
+
+jobs:
+  static:
+    name: M2 Coding Standard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: extdn/github-actions-m2/magento-coding-standard@master


### PR DESCRIPTION
https://github.com/extdn/github-actions-m2#magento-coding-standard