### PR TITLE
Replace usage of strftime()

### DIFF
--- a/Api/ScheduleManagementInterface.php
+++ b/Api/ScheduleManagementInterface.php
@@ -9,7 +9,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 
 interface ScheduleManagementInterface
 {
-    const TIME_FORMAT = '%Y-%m-%d %H:%M:00';
+    public const TIME_FORMAT = 'Y-m-d H:i:00';
 
     /**
      * @param int $scheduleId

--- a/Helper/Processor.php
+++ b/Helper/Processor.php
@@ -113,7 +113,7 @@ class Processor
                 $jobConfig['method']
             ));
         }
-        $schedule->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp()));
+        $schedule->setExecutedAt(date('Y-m-d H:i:s', $this->dateTime->gmtTimestamp()));
         $schedule->getResource()->save($schedule);
 
         try {
@@ -136,8 +136,8 @@ class Processor
             throw $e;
         }
 
-        $schedule->setStatus(Schedule::STATUS_SUCCESS)->setFinishedAt(strftime(
-            '%Y-%m-%d %H:%M:%S',
+        $schedule->setStatus(Schedule::STATUS_SUCCESS)->setFinishedAt(date(
+            'Y-m-d H:i:s',
             $this->dateTime->gmtTimestamp()
         ));
         $this->logger->info(sprintf(

--- a/Model/Manager.php
+++ b/Model/Manager.php
@@ -21,7 +21,7 @@ class Manager
      * @var ScheduleRepositoryInterface
      */
     private $scheduleRepository;
-    
+
     public function __construct(
         ScheduleManagementInterface $scheduleManagement,
         ScheduleRepositoryInterface $scheduleRepository
@@ -29,7 +29,7 @@ class Manager
         $this->scheduleManagement = $scheduleManagement;
         $this->scheduleRepository = $scheduleRepository;
     }
-    
+
     public function createCronJob($jobCode, $time)
     {
         return $this->scheduleManagement->createSchedule($jobCode, strtotime($time));
@@ -50,7 +50,7 @@ class Manager
             $schedule->setStatus($status);
         }
         if (!is_null($time)) {
-            $schedule->setScheduledAt(strftime(ScheduleManagementInterface::TIME_FORMAT, strtotime($time)));
+            $schedule->setScheduledAt(date(ScheduleManagementInterface::TIME_FORMAT, strtotime($time)));
         }
 
         $this->scheduleRepository->save($schedule);
@@ -68,7 +68,7 @@ class Manager
 
     /**
      * Dispatches cron schedule
-     * 
+     *
      * @param int $jobId
      * @param string $jobCode
      * @param \Magento\Cron\Model\Schedule $schedule
@@ -82,7 +82,7 @@ class Manager
 
         $this->scheduleManagement->execute($schedule->getId());
     }
-    
+
     /**
      * Dispatches cron schedule
      *
@@ -98,7 +98,7 @@ class Manager
     {
         return $this->scheduleManagement->listJobs();
     }
-    
+
     /**
      * @param String $jobCode
      * @param array | null $groups
@@ -108,7 +108,7 @@ class Manager
     {
         return $this->scheduleManagement->getGroupId($jobCode, $groups);
     }
-    
+
     public function scheduleNow($jobCode)
     {
         return $this->scheduleManagement->scheduleNow($jobCode);

--- a/Model/ScheduleManagement.php
+++ b/Model/ScheduleManagement.php
@@ -78,13 +78,13 @@ class ScheduleManagement implements ScheduleManagementInterface
 
     public function createSchedule(string $jobCode, $time = null): Schedule
     {
-        $time = strftime(ScheduleManagementInterface::TIME_FORMAT, $time ?? $this->dateTime->gmtTimestamp());
+        $time = date(ScheduleManagementInterface::TIME_FORMAT, $time ?? $this->dateTime->gmtTimestamp());
 
         $schedule = $this->scheduleFactory->create()
             ->setJobCode($jobCode)
             ->setStatus(Schedule::STATUS_PENDING)
             ->setCreatedAt(
-                strftime(ScheduleManagementInterface::TIME_FORMAT, $this->dateTime->gmtTimestamp())
+                date(ScheduleManagementInterface::TIME_FORMAT, $this->dateTime->gmtTimestamp())
             )->setScheduledAt($time);
 
         $this->scheduleRepository->save($schedule);
@@ -145,7 +145,7 @@ class ScheduleManagement implements ScheduleManagementInterface
         }
         $schedule->setData(
             'kill_request',
-            strftime(ScheduleManagementInterface::TIME_FORMAT, $this->dateTime->gmtTimestamp($timestamp))
+            date(ScheduleManagementInterface::TIME_FORMAT, $this->dateTime->gmtTimestamp($timestamp))
         );
         $this->scheduleRepository->save($schedule);
         return true;

--- a/Test/Integration/Model/ManagerTest.php
+++ b/Test/Integration/Model/ManagerTest.php
@@ -34,7 +34,7 @@ class ManagerTest extends TestCase
     {
         $cronJob = $this->manager->createCronJob(
             'expired_tokens_cleanup',
-            strftime('%Y-%m-%dT%H:%M', strtotime('+5 minutes'))
+            date('Y-m-d\TH:i', strtotime('+5 minutes'))
         );
 
         $this->assertInstanceOf(Schedule::class, $cronJob);

--- a/Test/Integration/_files/cron.php
+++ b/Test/Integration/_files/cron.php
@@ -12,7 +12,7 @@ $cron = $objectManager->create(Schedule::class);
 $cron->setId(ManagerTest::FIXTURE_CRON_ID)
     ->setJobCode('fake_job')
     ->setStatus(Schedule::STATUS_PENDING)
-    ->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
-    ->setScheduledAt(strftime('%Y-%m-%d %H:%M:%S', strtotime('+5 minutes')));
+    ->setCreatedAt(date('Y-m-d H:i:s', time()))
+    ->setScheduledAt(date('Y-m-d H:i:s', strtotime('+5 minutes')));
 
 $cron->save();


### PR DESCRIPTION
Fixes #183
`strftime()` has been deprecated in PHP version 8.1.