### PR TITLE
Update templates to close tags correctly

### DIFF
--- a/view/adminhtml/web/template/form/element/inputWithDatalist.html
+++ b/view/adminhtml/web/template/form/element/inputWithDatalist.html
@@ -18,5 +18,5 @@ with a <datalist> element added to the input -->
             maxlength: 255
     }"/>
 <datalist attr="id: uid + '-options'" each="options">
-    <option attr="value: $data.value" />
+    <option attr="value: $data.value"></option>
 </datalist>

--- a/view/adminhtml/web/template/timeline/timeline.html
+++ b/view/adminhtml/web/template/timeline/timeline.html
@@ -1,5 +1,5 @@
 <div class="cronjobmanager" >
-    <span>Total Records: <text args="total" /></span>
+    <span>Total Records: <text args="total"></text></span>
     <div class="timeline-scale">
         <div class="data-slider"
             range="
@@ -16,19 +16,19 @@
        <div data-role="spinner" data-component="timeline_container.timeline_panel" 
            class="admin__data-grid-loading-mask">
             <div class="spinner">
-                <span/><span/><span/><span/><span/><span/><span/><span/>
+                <span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span>
             </div>
        </div>
        <div class="left-content">
             <div class="timeline-unit row hours">
                 <div class="timeframe timeline-date">
-                    <span data-bind="text: range.timeframe"/>
+                    <span data-bind="text: range.timeframe"></span>
                 </div>
             </div>
             <fastForEach args="data: transformedRows">
                 <div class="row">
                     <div class="job-code">
-                        <text args="$data.key" />
+                        <text args="$data.key"></text>
                     </div>
                 </div>
             </fastForEach>
@@ -45,7 +45,7 @@
                                         data-bind="style: { 
                                             width: 'calc(' + $parent.width + 'px' + '/' + $parent.range.totalHours + ')' 
                                         }">
-                                        <span data-bind="text: $data" />
+                                        <span data-bind="text: $data"></span>
                                     </div>
                                 </div>
                             </div>
@@ -65,7 +65,7 @@
                                             style: {
                                                 width: $parentContext.$parent.getCronWidth($data) + 'px',
                                                 transform: 'translateX(' + $parentContext.$parent.getOffset($data) + ')'
-                                            }"/>
+                                            }"></div>
                                         <div tooltip=" trigger: '[data-tooltip-trigger=update-' + schedule_id + ']',
                                             action: 'hover',
                                             delay: 0,
@@ -73,51 +73,51 @@
                                             closeButton: false">
                                             <div>
                                                 <div class="data-tooltip-title">
-                                                    <text args="job_code"/>
+                                                    <text args="job_code"></text>
                                                 </div>
                                                 <div class="data-tooltip-content">
                                                     <dl class="staging-events-summary">
                                                         <dt>
-                                                            <translate args="'Schedule Id'"/>:
+                                                            <translate args="'Schedule Id'"></translate>:
                                                         </dt>
                                                         <dd>
-                                                            <text args="schedule_id"/>
+                                                            <text args="schedule_id"></text>
                                                         </dd>
                                                         <dt>
-                                                            <translate args="'Process Id'"/>:
+                                                            <translate args="'Process Id'"></translate>:
                                                         </dt>
                                                         <dd>
-                                                            <text args="pid"/>
+                                                            <text args="pid"></text>
                                                         </dd>
                                                         <dt>
-                                                            <translate args="'Status'"/>:
+                                                            <translate args="'Status'"></translate>:
                                                         </dt>
                                                         <dd>
-                                                            <text args="status"/>
+                                                            <text args="status"></text>
                                                         </dd>
                                                         <dt>
-                                                            <translate args="'Created at'"/>:
+                                                            <translate args="'Created at'"></translate>:
                                                         </dt>
                                                         <dd>
-                                                            <time text="$parentContext.$parent.formatTime(created_at)"/>
+                                                            <time text="$parentContext.$parent.formatTime(created_at)"></time>
                                                         </dd>
                                                         <dt>
-                                                            <translate args="'Scheduled at'"/>:
+                                                            <translate args="'Scheduled at'"></translate>:
                                                         </dt>
                                                         <dd>
-                                                            <time text="$parentContext.$parent.formatTime(scheduled_at) || 'N/A'"/>
+                                                            <time text="$parentContext.$parent.formatTime(scheduled_at) || 'N/A'"></time>
                                                         </dd>
                                                         <dt>
-                                                            <translate args="'Executed at'"/>:
+                                                            <translate args="'Executed at'"></translate>:
                                                         </dt>
                                                         <dd>
-                                                            <time text="$parentContext.$parent.formatTime(executed_at) || 'N/A'"/>
+                                                            <time text="$parentContext.$parent.formatTime(executed_at) || 'N/A'"></time>
                                                         </dd>
                                                         <dt>
-                                                            <translate args="'Finished at'"/>:
+                                                            <translate args="'Finished at'"></translate>:
                                                         </dt>
                                                         <dd>
-                                                            <time text="$parentContext.$parent.formatTime(finished_at) || 'N/A'"/>
+                                                            <time text="$parentContext.$parent.formatTime(finished_at) || 'N/A'"></time>
                                                         </dd>
                                                     </dl>
                                                 </div>

--- a/view/adminhtml/web/template/visualizer/details.html
+++ b/view/adminhtml/web/template/visualizer/details.html
@@ -9,45 +9,45 @@
                parentScope: '[data-tooltip-search-scope=search-scope-' + $index + ']'">
     <div>
         <div class="data-tooltip-title" ko-scope="requestChild('name')">
-            <text args="getLabel($row())"/>
+            <text args="getLabel($row())"></text>
         </div>
  
         <div class="data-tooltip-content">
             <dl class="staging-events-summary">
             	<dt>
-                    <translate args="'Schedule Id'"/>:
+                    <translate args="'Schedule Id'"></translate>:
                 </dt>
                 <dd ko-scope="requestChild('schedule_id')">
-                    <text args="getLabel($row())"/>
+                    <text args="getLabel($row())"></text>
                 </dd>
                 
             	<dt>
-                    <translate args="'Job Code'"/>:
+                    <translate args="'Job Code'"></translate>:
                 </dt>
                 <dd ko-scope="requestChild('job_code')">
-                    <text args="getLabel($row())"/>
+                    <text args="getLabel($row())"></text>
                 </dd>
             
                 <dt>
-                    <translate args="'Status'"/>:
+                    <translate args="'Status'"></translate>:
                 </dt>
                 <dd ko-scope="requestChild('status')">
-                    <text args="getLabel($row())"/>
+                    <text args="getLabel($row())"></text>
                 </dd>
  
                 <dt>
-                    <translate args="'Start'"/>:
+                    <translate args="'Start'"></translate>:
                 </dt>
                 <dd>
-                    <time text="formatDetails(getStartDate($row()))"/>
+                    <time text="formatDetails(getStartDate($row()))"></time>
                 </dd>
  
                 <ifnot args="isPermanent($row())">
                     <dt>
-                        <translate args="'End'"/>:
+                        <translate args="'End'"></translate>:
                     </dt>
                     <dd>
-                        <time text="formatDetails(getEndDate($row()))"/>
+                        <time text="formatDetails(getEndDate($row()))"></time>
                     </dd>
                 </ifnot>
             </dl>
@@ -57,7 +57,7 @@
                     repeat="foreach: getVisibleActions($row()._rowIndex), item: '$action'"
                     attr="href: $action().href"
                     click="getActionHandler($action())">
-                    <span text="$action().label"/>
+                    <span text="$action().label"></span>
                 </a>
             </div>
         </div>

--- a/view/adminhtml/web/template/visualizer/record.html
+++ b/view/adminhtml/web/template/visualizer/record.html
@@ -1,18 +1,18 @@
-<div class="timeline-event-details" render="detailsTmpl"/>
+<div class="timeline-event-details" render="detailsTmpl"></div>
 <div class="timeline-event" attr="'data-tooltip-trigger': 'update-' + $index">
     <strong class="timeline-event-title" ko-scope="requestChild('job_code')">
-        <text args="getLabel($row())"/>
+        <text args="getLabel($row())"></text>
     </strong>
     <div class="timeline-event-actions">
         <button type="button"
                 attr="title: $t('To Start')"
                 class="timeline-action _tostart">
-            <span translate="'To Start'"/>
+            <span translate="'To Start'"></span>
         </button>
         <button type="button"
                 attr="title: $t('To End')"
                 class="timeline-action _toend">
-            <span translate="'To End'"/>
+            <span translate="'To End'"></span>
         </button>
     </div>
     <if args="isActive($row())">

--- a/view/adminhtml/web/template/visualizer/toolbar.html
+++ b/view/adminhtml/web/template/visualizer/toolbar.html
@@ -1,17 +1,17 @@
 <div class="admin__data-grid-header" afterRender="$data.setToolbarNode">
     <div class="admin__data-grid-header-row">
-        <div class="admin__data-grid-actions-wrap" each="getRegion('dataGridActions')" render=""/>
-        <scope args="columnsProvider" render="viewSwitcherTmpl"/>
-        <each args="getRegion('dataGridFilters')" render=""/>
+        <div class="admin__data-grid-actions-wrap" each="getRegion('dataGridActions')" render=""></div>
+        <scope args="columnsProvider" render="viewSwitcherTmpl"></scope>
+        <each args="getRegion('dataGridFilters')" render=""></each>
     </div>
     <div class="admin__data-grid-header-row row row-gutter">
-        <div class="col-xs-2" if="hasChild('listing_massaction')" ko-scope="requestChild('listing_massaction')" render=""/>
+        <div class="col-xs-2" if="hasChild('listing_massaction')" ko-scope="requestChild('listing_massaction')" render=""></div>
         <div css="
             'col-xs-10': hasChild('listing_massaction'),
             'col-xs-12': !hasChild('listing_massaction')">
             <div class="row" ko-scope="requestChild('listing_paging')">
-                <div class="col-xs-3" render="totalTmpl"/>
-                <div class="col-xs-9" render=""/>
+                <div class="col-xs-3" render="totalTmpl"></div>
+                <div class="col-xs-9" render=""></div>
             </div>
         </div>
     </div>

--- a/view/adminhtml/web/template/visualizer/visualizer.html
+++ b/view/adminhtml/web/template/visualizer/visualizer.html
@@ -41,10 +41,10 @@
                     position: 'top',
                     closeButton: false
                 ">
-                    <text args="isToday($date()) ? formatHeader($date()) \: formatHeader($date())"/>
+                    <text args="isToday($date()) ? formatHeader($date()) \: formatHeader($date())"></text>
                 </div>
                 <time attr="'data-tooltip-trigger': $index" class="timeline-date">
-                    <text args="isToday($date()) ? $t('\(Today\) ' + formatHeader($date())) \: formatHeader($date())"/>
+                    <text args="isToday($date()) ? $t('\(Today\) ' + formatHeader($date())) \: formatHeader($date())"></text>
                 </time>
             </li>
         </ul>
@@ -60,15 +60,15 @@
                         _running: isRunning($row()),
                         _pending: isPending($row())	
                     "
-                    render="recordTmpl"/>
+                    render="recordTmpl"></li>
             </if>
 
             <ifnot args="hasData()">
                 <li class="timeline-item" data-role="no-data-msg">
                     <div class="timeline-event">
                         <span class="timeline-event-title"
-                                translate="'We couldn\'t find any records.'"/>
-                        <div class="timeline-event-info"/>
+                                translate="'We couldn\'t find any records.'"></span>
+                        <div class="timeline-event-info"></div>
                     </div>
                 </li>
             </ifnot>


### PR DESCRIPTION
As of Magento 2.4.4 self-closing tags in component templates are no longer allowed and components do not render.

[Release Notes](https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-4.html#infrastructure)

> HTML tags are now nested and closed properly to meet standards in JQuery 3.5.x for non-void elements including custom elements.