### PR TITLE
Notify user when unable to set area

### DIFF
--- a/Console/Command/KillJob.php
+++ b/Console/Command/KillJob.php
@@ -116,6 +116,13 @@ class KillJob extends Command
             $this->state->setAreaCode(Area::AREA_ADMINHTML);
         } catch (LocalizedException $exception) {
             // Area code is already set
+            $output->writeln(
+                __(
+                    'WARNING: cannot set area code. This is usually caused by a'
+                    . ' command in a third party module calling'
+                    . ' state->setAreaCode() in its "configure()" method.'
+                )
+            );
         }
 
         /** @var string $jobCode */

--- a/Console/Command/Showjobs.php
+++ b/Console/Command/Showjobs.php
@@ -52,6 +52,13 @@ class Showjobs extends Command
             $this->state->setAreaCode(Area::AREA_ADMINHTML);
         } catch (\Magento\Framework\Exception\LocalizedException $exception) {
             // Area code is already set
+            $output->writeln(
+                __(
+                    'WARNING: cannot set area code. This is usually caused by a'
+                    . ' command in a third party module calling'
+                    . ' state->setAreaCode() in its "configure()" method.'
+                )
+            );
         }
 
         try {


### PR DESCRIPTION
This resolves the coding standard violations for empty catch blocks.
`[Magento2.CodeAnalysis.EmptyBlock.DetectedCatch] Empty CATCH statement detected`
