### PR TITLE
Add support for Magento 2.4.6

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,6 +2,35 @@ name: ExtDN M2 Integration Tests
 on: [ push, pull_request ]
 
 jobs:
+  mage246:
+    name: Magento 2 Integration Tests (Magento v2.4.6)
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --tmpfs /tmp:rw --tmpfs /var/lib/mysql:rw --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      es:
+        image: docker.io/wardenenv/elasticsearch:8.1
+        ports:
+          - 9200:9200
+        env:
+          'discovery.type': single-node
+          'xpack.security.enabled': false
+          ES_JAVA_OPTS: "-Xms64m -Xmx512m"
+        options: --health-cmd="curl localhost:9200/_cluster/health?wait_for_status=yellow&timeout=60s" --health-interval=10s --health-timeout=5s --health-retries=3
+    steps:
+      - uses: actions/checkout@v2
+      - name: M2 Integration Tests with Magento 2
+        uses: extdn/github-actions-m2/magento-integration-tests/8.2@master
+        with:
+          module_name: EthanYehuda_CronjobManager
+          composer_name: ethanyehuda/magento2-cronjobmanager
+          ce_version: 2.4.6
+
   mage244:
     name: Magento 2 Integration Tests (Magento v2.4.4)
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,3 +18,9 @@ jobs:
       - uses: docker://yireo/github-actions-magento-unit-tests:8.1
         env:
           MAGENTO_VERSION: '2.4.4'
+      - uses: docker://yireo/github-actions-magento-unit-tests:8.1
+        env:
+          MAGENTO_VERSION: '2.4.5'
+      - uses: docker://yireo/github-actions-magento-unit-tests:8.2
+        env:
+          MAGENTO_VERSION: '2.4.6'

--- a/view/adminhtml/web/js/timeline/timeline.js
+++ b/view/adminhtml/web/js/timeline/timeline.js
@@ -126,7 +126,7 @@ define([
         updateTimelineWidth: function () {
             var range = this.rows[0].range;
 
-            var first = moment.unix(range.first); 
+            var first = moment.unix(range.first);
             first = first.startOf('hour');
 
             var last = moment.unix(range.last);
@@ -134,7 +134,7 @@ define([
 
             this.width = (last.diff(first, 'seconds') + 3600) / this.scale;
         },
-        
+
         /**
          * Updates data of a range object,
          * e.g. total hours, first hour and last hour, etc.
@@ -172,12 +172,12 @@ define([
             var first = firstHour.format(this.timeframeFormat),
                 last  = lastHour.format(this.timeframeFormat);
 
-            return first + " - " + last; 
+            return first + " - " + last;
         },
 
         /**
          * Converts unix timestamp to moment object
-         *        
+         *
          * @param {String} dateStr
          * @returns {Moment}
          */
@@ -195,7 +195,7 @@ define([
         getFirstHour: function (useMoment) {
             var firstHour = this.rows[0].range.first;
             if (useMoment == null || useMoment) {
-                var first = this.createDate(firstHour); 
+                var first = this.createDate(firstHour);
                 return first.startOf('hour');
             }
             return new Date(new Date(new Date(firstHour * 1000).setMinutes(0)).setSeconds(0));
@@ -210,13 +210,13 @@ define([
          */
         getLastHour: function () {
             var lastHour = this.rows[0].range.last;
-            var last = this.createDate(lastHour); 
+            var last = this.createDate(lastHour);
             return last.add(1, 'hour').startOf('hour');
         },
 
         /**
          * Returns offset relative to the time now
-         * 
+         *
          * @returns {String}
          */
         setNow: function () {
@@ -267,7 +267,7 @@ define([
          * Handler of the data providers' 'reloaded' event.
          */
         onDataReloaded: function () {
-            if (Object.keys(this.rows).length < 1 
+            if (Object.keys(this.rows).length < 1
                 || this.rows == undefined) {
                 loader.get('timeline_container.timeline_panel').hide();
                 return;
@@ -301,6 +301,9 @@ define([
             var properties = [];
             var index = 0;
             ko.utils.objectForEach(obj, function (key, value) {
+                if (key == 'showTotalRecords' && typeof value == 'boolean') {
+                    return;
+                }
                 properties.push({ index: index, key: key, value: value });
                 index++;
             });
@@ -315,7 +318,7 @@ define([
          */
         afterTimelineRender: function () {
             resolver(this.hideLoader, this);
-            var clicked = false, 
+            var clicked = false,
                 scrollVertical = true,
                 scrollHorizontal = true,
                 cursor = null,
@@ -327,7 +330,7 @@ define([
                 var $el = $(el);
                 scrollVertical && $(window).scrollTop(($(window).scrollTop() + (clickY - e.pageY)));
                 scrollHorizontal && $el.scrollLeft(($el.scrollLeft() + (clickX - e.pageX)));
-            } 
+            }
 
             $('.timeline-container').on({
                 'mousemove': function(e) {
@@ -348,4 +351,3 @@ define([
         }
     });
 });
-


### PR DESCRIPTION
While testing this extension on Magento v2.4.6, I noticed that the timeline did not work. This pull request fixes that problem, and adds Magento 2.4.6 to the automated tests already in place.

Related to #188