### PR TITLE
Replace 'dispatch now' feature with 'schedule now'

### DIFF
--- a/Controller/Adminhtml/Manage/Job/Dispatch.php
+++ b/Controller/Adminhtml/Manage/Job/Dispatch.php
@@ -2,8 +2,7 @@
 
 namespace EthanYehuda\CronjobManager\Controller\Adminhtml\Manage\Job;
 
-use EthanYehuda\CronjobManager\Model\Manager;
-use Magento\Framework\View\Result\PageFactory;
+use EthanYehuda\CronjobManager\Model\ScheduleManagement;
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\App\Action;
 
@@ -11,47 +10,37 @@ class Dispatch extends Action
 {
     public const ADMIN_RESOURCE = "EthanYehuda_CronjobManager::cronjobmanager";
 
-    /**
-     * @var \Magento\Framework\View\Result\PageFactory
-     */
-    private $resultPageFactory;
+    /** @var ScheduleManagement */
+    private $scheduleManagement;
 
     /**
-     * @var Manager
-     */
-    private $cronJobManager;
-
-    /**
-     * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
-     * @param \Magento\Backend\App\Action\Context $context
+     * @param Context $context
+     * @param ScheduleManagement $scheduleManagement
      */
     public function __construct(
-        PageFactory $resultPageFactory,
         Context $context,
-        Manager $cronJobManager
+        ScheduleManagement $scheduleManagement
     ) {
         parent::__construct($context);
-        $this->resultPageFactory = $resultPageFactory;
-        $this->cronJobManager = $cronJobManager;
+        $this->scheduleManagement = $scheduleManagement;
     }
 
     /**
-     * Save cronjob
+     * Schedule a new run of the selected jobcode
      *
-     * @return Void
+     * @return void
      */
     public function execute()
     {
-        $jobId = $this->getRequest()->getParam('id');
         $jobCode = $this->getRequest()->getParam('job_code');
+
         try {
-            $this->cronJobManager->dispatchCron($jobId, $jobCode);
+            $this->scheduleManagement->scheduleNow($jobCode);
+            $this->getMessageManager()->addSuccessMessage(__('Successfully scheduled selected job'));
         } catch (\Exception $e) {
             $this->getMessageManager()->addErrorMessage($e->getMessage());
-            $this->_redirect('*/manage/index/');
-            return;
         }
-        $this->getMessageManager()->addSuccessMessage("Successfully Dispatched Cron Job: {$jobCode}");
-        $this->_redirect('*/manage/index/');
+
+        $this->_redirect('*/manage/index');
     }
 }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ The configuration panel boasts a list of features including:
 
 * Schedule Now
 
-   Gives the ability to schedule any task immediately and in the background. Unlike the dispatch feature on the dashboard, which runs the cron on the forefront, scheduling a task from the configuration panel will allow the system to call it asynchronously
+   Gives the ability to schedule any task immediately and in the background.
+   Scheduling a task from the configuration panel will allow the system to call it asynchronously.
 
 * Cron Runner
 

--- a/Ui/Component/Listing/Column/CronActions.php
+++ b/Ui/Component/Listing/Column/CronActions.php
@@ -96,11 +96,12 @@ class CronActions extends Column
                                     'job_code' => $item['job_code'],
                                 ]
                             ),
-                            'label' => __('Dispatch'),
+                            'label' => __('Schedule duplicate job'),
                             'confirm' => [
-                                'job_code' => __('Dispatch %1', $jobCode),
+                                'job_code' => __('Schedule %1', $jobCode),
                                 'message' => __(
-                                    'Are you sure you want to <b>dispatch %1</b>? This may be time consuming and resource intensive.',
+                                    'Are you sure you want to <b>schedule %1</b> to run (again) now?'
+                                    . ' This may be time consuming and resource intensive.',
                                     $jobCode
                                 ),
                             ],

--- a/view/adminhtml/ui_component/cronjobmanager_manage_grid.xml
+++ b/view/adminhtml/ui_component/cronjobmanager_manage_grid.xml
@@ -113,12 +113,12 @@
 				<argument name="data" xsi:type="array">
 					<item name="config" xsi:type="array">
 						<item name="confirm" xsi:type="array">
-							<item name="title" xsi:type="string" translate="true">Dispatch Now</item>
-							<item name="message" xsi:type="string" translate="true">WARNING: Depending on the actions you selected, (and the amount of them) this process
+							<item name="title" xsi:type="string" translate="true">Schedule duplicate jobs</item>
+							<item name="message" xsi:type="string" translate="true">WARNING: Depending on the actions you selected (and the amount of them), this process
 							can consume a lot of time and memory. Are you sure you want to proceed?</item>
 						</item>
 						<item name="type" xsi:type="string">dispatch</item>
-						<item name="label" xsi:type="string" translate="true">Dispatch Now</item>
+						<item name="label" xsi:type="string" translate="true">Schedule duplicate</item>
 						<item name="url" xsi:type="url" path="cronjobmanager/manage_job/massDispatch" />
 					</item>
 				</argument>


### PR DESCRIPTION
The "dispatch now" feature will run the selected Magento cron job(s) within the adminhtml area, which causes issues with some jobs. For an example of the hard-to-diagnose issues, see https://github.com/Ethan3600/magento2-CronjobManager/issues/191.

This pull request replaces the feature to avoid its accidental use. The replacement is an existing feature: schedule now. There are now more ways to schedule a job code to be run "now" via the normal Magento cron command, which should be running anyway. If the normal Magento cron command isn't running, then a warning is displayed at the top of the admin advising so.

Note that I've targeted a new `2.x` branch as this will need to be released as a breaking change and cannot be included in the `1.x` release line / branch.