### PR TITLE
Ensure items in timeline view are visible

### DIFF
--- a/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
+++ b/view/adminhtml/web/js/lib/knockout/bindings/virtual-foreach.js
@@ -202,25 +202,19 @@ define([
                 }
             };
 
-            var windowTimer = null;
-            $(window).on('scroll', function() {
-                if (windowTimer !== null) {
-                    clearTimeout(windowTimer);
+            var debounceRefresh = function() {
+                if (debounceRefresh.timer) {
+                    clearTimeout(debounceRefresh.timer);
                 }
-                windowTimer = setTimeout(function() {
+
+                debounceRefresh.timer = setTimeout(function() {
                     raf(refresh);
                 }, 150);
-            });
+            };
 
-            var panelTimer = null;
-            $timelinePanel.on('scroll', function() {
-                if (panelTimer !== null) {
-                    clearTimeout(panelTimer);
-                }
-                panelTimer = setTimeout(function() {
-                    raf(refresh);
-                }, 1000);
-            });
+            $(window).on('scroll', debounceRefresh);
+            $timelinePanel.on('scroll', debounceRefresh);
+            $timelineCont.on('scroll', debounceRefresh);
 
             $timelineCont.on('timeline.ready', function() {
                 $(window).trigger('scroll');


### PR DESCRIPTION
When the timeline initially loads, the items in view were not showing up. This has been mentioned in https://github.com/Ethan3600/magento2-CronjobManager/issues/76#issuecomment-462242216. When scrolling up/down, the items would appear; however when scrolling left/right, the items would not show up as expected until an up/down scroll was performed. This pull request fixes both of these issues.