### PR TITLE
add support for php 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ethanyehuda/magento2-cronjobmanager",
     "description": "A module for managing scheduled cron jobs from magento's admin panel",
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-posix": "*",
         "magento/framework": "^102.0 || ^103.0",
         "magento/module-backend": "^100.0 || ^101.0 || ^102.0",


### PR DESCRIPTION
add support for php 8.4 which is now supported in magento2 2.4.8