### PR TITLE
Fix magento 2.4.9 support, add synfony 7.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "magento/module-store": "^100.0 || ^101.0",
         "magento/module-ui": "^100.0 || ^101.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^4.0 || ^5.0 || ^6.0"
+        "symfony/console": "^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "ext-pcntl": "*"


### PR DESCRIPTION
Fix magento 2.4.9 support, add synfony 7.x support

```
 - ethanyehuda/magento2-cronjobmanager[v2.2.1, ..., v2.2.2] require symfony/console ^4.0 || ^5.0 || ^6.0 -> found symfony/console[v4.0.0, ..., v4.4.49, v5.0.0, ..., v5.4.47, v6.0.0, ..., v6.4.39] but the package is fixed to v7.4.9 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```