### PR TITLE
Fix race in CleanRunningJobs marking finished jobs as 'Process went away'

### DIFF
--- a/Model/CleanRunningJobs.php
+++ b/Model/CleanRunningJobs.php
@@ -7,6 +7,7 @@ namespace EthanYehuda\CronjobManager\Model;
 use EthanYehuda\CronjobManager\Api\Data\ScheduleInterface;
 use EthanYehuda\CronjobManager\Api\ScheduleRepositoryAdapterInterface;
 use Magento\Cron\Model\ResourceModel\Schedule\CollectionFactory;
+use Magento\Cron\Model\ResourceModel\Schedule as ScheduleResource;
 use Magento\Cron\Model\Schedule;
 use Magento\Framework\Stdlib\DateTime\DateTime;
 
@@ -20,12 +21,14 @@ class CleanRunningJobs
      * @param ProcessManagement $processManagement
      * @param DateTime $dateTime
      * @param ClockInterface $clock
+     * @param ScheduleResource $scheduleResource
      */
     public function __construct(
         private readonly ScheduleRepositoryAdapterInterface $scheduleRepository,
         private readonly ProcessManagement $processManagement,
         private readonly DateTime $dateTime,
         private readonly ClockInterface $clock,
+        private readonly ScheduleResource $scheduleResource,
     ) {
     }
 
@@ -47,18 +50,45 @@ class CleanRunningJobs
                 continue;
             }
 
-            $messages = [];
-            if ($schedule->getMessages()) {
-                $messages[] = $schedule->getMessages();
+            /*
+             * $runningJobs is a stale snapshot: with multiple cron groups running in
+             * separate processes, a short-lived job can save its final status and exit
+             * between loading the snapshot and the PID check above. A dead PID guarantees
+             * the process can never write again, so lock the row and re-check: if it is
+             * still "running" now, the process genuinely died mid-job.
+             */
+            $connection = $this->scheduleResource->getConnection();
+            $connection->beginTransaction();
+            try {
+                $row = $connection->fetchRow(
+                    $connection->select()
+                        ->from($this->scheduleResource->getMainTable())
+                        ->where('schedule_id = ?', $schedule->getScheduleId())
+                        ->forUpdate(true)
+                );
+
+                if (!$row || $row['status'] !== ScheduleInterface::STATUS_RUNNING) {
+                    $connection->commit();
+                    continue;
+                }
+
+                $messages = [];
+                if (!empty($row['messages'])) {
+                    $messages[] = $row['messages'];
+                }
+
+                $messages[] = __('Process went away at %1', $this->dateTime->gmtDate(null, $this->clock->now()));
+
+                $schedule
+                    ->setStatus(Schedule::STATUS_ERROR)
+                    ->setMessages(implode("\n", $messages));
+
+                $this->scheduleRepository->save($schedule);
+                $connection->commit();
+            } catch (\Throwable $exception) {
+                $connection->rollBack();
+                throw $exception;
             }
-
-            $messages[] = __('Process went away at %1', $this->dateTime->gmtDate(null, $this->clock->now()));
-
-            $schedule
-                ->setStatus(Schedule::STATUS_ERROR)
-                ->setMessages(implode("\n", $messages));
-
-            $this->scheduleRepository->save($schedule);
         }
     }
 }

--- a/Test/Integration/CleanRunningJobsTest.php
+++ b/Test/Integration/CleanRunningJobsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EthanYehuda\CronjobManager\Test\Integration;
 
+use EthanYehuda\CronjobManager\Api\ScheduleRepositoryAdapterInterface;
+use EthanYehuda\CronjobManager\Model\CleanRunningJobs;
 use EthanYehuda\CronjobManager\Model\ClockInterface;
 use EthanYehuda\CronjobManager\Model\ErrorNotificationInterface;
 use EthanYehuda\CronjobManager\Test\Util\FakeClock;
@@ -71,6 +73,49 @@ class CleanRunningJobsTest extends TestCase
         $this->givenRunningScheduleWithActiveProcess($schedule);
         $this->whenEventIsDispatched('process_cron_queue_before');
         $this->thenScheduleHasStatus($schedule, Schedule::STATUS_RUNNING);
+    }
+
+    /**
+     * A short-lived job can save its final status and exit between the watchdog
+     * loading its list of "running" schedules and checking the job's PID. The
+     * watchdog must not overwrite that final status with "Process went away".
+     */
+    public function testJobFinishedAfterSnapshotIsNotMarkedAsError()
+    {
+        $this->givenRunningScheduleWithInactiveProcess($schedule);
+        $this->givenScheduleIsRunningOnHost($schedule, \gethostname());
+        $staleSnapshot = $this->givenWatchdogSnapshotContaining($schedule);
+
+        $schedule->setStatus(Schedule::STATUS_SUCCESS);
+        $schedule->save();
+
+        $this->whenCleanRunningJobsExecutesWithSnapshot($staleSnapshot);
+        $this->thenScheduleHasStatus($schedule, Schedule::STATUS_SUCCESS);
+    }
+
+    private function givenWatchdogSnapshotContaining(Schedule $schedule): array
+    {
+        /** @var ScheduleRepositoryAdapterInterface $scheduleRepository */
+        $scheduleRepository = $this->objectManager->get(ScheduleRepositoryAdapterInterface::class);
+
+        return [$scheduleRepository->get((int)$schedule->getId())];
+    }
+
+    private function whenCleanRunningJobsExecutesWithSnapshot(array $staleSnapshot): void
+    {
+        $realRepository = $this->objectManager->get(ScheduleRepositoryAdapterInterface::class);
+        $staleRepository = $this->createMock(ScheduleRepositoryAdapterInterface::class);
+        $staleRepository->method('getByStatus')->willReturn($staleSnapshot);
+        $staleRepository->method('save')->willReturnCallback(
+            fn ($schedule, $scheduleId = null) => $realRepository->save($schedule, $scheduleId)
+        );
+
+        /** @var CleanRunningJobs $cleanRunningJobs */
+        $cleanRunningJobs = $this->objectManager->create(
+            CleanRunningJobs::class,
+            ['scheduleRepository' => $staleRepository]
+        );
+        $cleanRunningJobs->execute();
     }
 
     private function givenRunningScheduleWithInactiveProcess(&$schedule)


### PR DESCRIPTION
Hey,

After I've enabled the e-mail on cron errors I've discovered a weird issue. A lot of our crons exited with "process went away" but nothing was really wrong. After a lengthy debug session and multiple fixes to cronjob tab (seperate processes etc.) I came to this conclusion together with Claude that this is a race condition that happens more often on a very busy server for example I've had 1000 cronjobs runs per hour on this server. So I saw a lot of "process went away" e-mails. On a lesser busy server this wasn't really an issue, because the concurrency couldn't hit that often.

After applying this fix I was able to reduce the errors and have successful cronjobs running on production.

So here by the explanation;

CleanRunningJobs runs on process_cron_queue_before in every cron:run invocation, so with separate-process cron groups multiple watchdogs run concurrently with in-flight jobs. The list of 'running' schedules it loads is a stale snapshot: a short-lived job (e.g. consumers_runner, ~10ms) can save its final 'success' status and exit between the snapshot load and the posix_kill() PID check. The watchdog then saved the stale object as error 'Process went away', clobbering the success.

Since a dead PID guarantees the process already wrote its final status, re-load the schedule and only flag it when it is still 'running' in the database, i.e. the process genuinely crashed mid-job.

Timeline of one occurrence (times illustrative):                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                   
12:00:30.100  cron group "index" child starts, watchdog loads snapshot: schedule 987 (consumers_runner) status=running, pid=12345
12:00:30.120  pid 12345 finishes consumers_runner, saves status=success, exits
12:00:30.200  watchdog reaches schedule 987: posix_kill(12345, 0) → dead
                → saves stale object: status=error "Process went away"
                → the success written at .120 is overwritten